### PR TITLE
update CNN ROI modules

### DIFF
--- a/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/EvaluateROIEff_module.cc
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/EvaluateROIEff_module.cc
@@ -2,9 +2,15 @@
 // Class:       EvaluateROIEff
 // Plugin Type: analyzer (art v3_05_00)
 // File:        EvaluateROIEff_module.cc
-//
+// 
 // Generated at Sun May  3 23:16:14 2020 by Tingjun Yang using cetskelgen
 // from cetlib version v3_10_00.
+// 
+// Author: Tingjun Yang, tjyang@fnal.gov
+//         Wanwei Wu, wwu@fnal.gov
+//
+// About: ROI efficiency and purity evaluation using "signal". Here, "signal"
+//        is consecutive energy deposits based on tdc ticks.
 ////////////////////////////////////////////////////////////////////////
 
 #include "art/Framework/Core/EDAnalyzer.h"
@@ -16,20 +22,23 @@
 #include "fhiclcpp/ParameterSet.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
-#include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
-#include "lardataobj/RecoBase/Wire.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "larcore/Geometry/Geometry.h"
 #include "lardataobj/Simulation/SimChannel.h"
-#include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h"
+#include "lardataobj/RecoBase/Wire.h"
 #include "larevt/CalibrationDBI/Interface/ChannelStatusService.h"
+#include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h"
 
-#include "TEfficiency.h"
 #include "TH1D.h"
+#include "TEfficiency.h"
+
+using namespace std;
 
 namespace nnet {
   class EvaluateROIEff;
 }
+
 
 class nnet::EvaluateROIEff : public art::EDAnalyzer {
 public:
@@ -47,104 +56,432 @@ public:
   void analyze(art::Event const& e) override;
 
 private:
+
   void beginJob() override;
   void endJob() override;
+  bool isSignalInROI(int starttick, int endtick, int maxtick, int roistart, int roiend);
   // Declare member data here.
-  TH1D* h_energy[3];
-  TH1D* h_energy_roi[3];
-  TEfficiency* eff_energy[3];
-
   art::InputTag fWireProducerLabel;
+  art::InputTag fSimulationProducerLabel; // The name of the producer that tracked simulated particles through the detector
+
+  TH1D *h_energy[3];
+  TH1D *h_energy_roi[3];
+
+  TEfficiency *eff_energy[3];
+
+  TH1D *h_purity[3];  
+  TH1D *h_purity_all;  
+
+  TH1D *h_roi[3];
+  TH1D *h1_roi_max[3];
+  TH1D *h1_roi_max_sim[3];
+
+  TH1D *h1_tickdiff_max[3];
+
+  int fCount_Roi_sig[3] = {0,0,0};
+  int fCount_Roi_total[3] = {0,0,0};
 };
 
+
 nnet::EvaluateROIEff::EvaluateROIEff(fhicl::ParameterSet const& p)
-  : EDAnalyzer{p}, fWireProducerLabel(p.get<art::InputTag>("WireProducerLabel", ""))
+  : EDAnalyzer{p},
+  fWireProducerLabel(p.get<art::InputTag>("WireProducerLabel","")),
+  fSimulationProducerLabel(p.get<art::InputTag>("SimulationProducerLabel","largeant"))
+  // More initializers here.
 {
   // Call appropriate consumes<>() for any products to be retrieved by this module.
 }
 
-void
-nnet::EvaluateROIEff::analyze(art::Event const& e)
+void nnet::EvaluateROIEff::analyze(art::Event const& e)
 {
 
   auto const* geo = lar::providerFrom<geo::Geometry>();
-  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService>()->DataFor(e);
-  auto const detProp =
-    art::ServiceHandle<detinfo::DetectorPropertiesService>()->DataFor(e, clockData);
-  auto const& chStatus = art::ServiceHandle<lariov::ChannelStatusService>()->GetProvider();
+  auto const* detprop = lar::providerFrom<detinfo::DetectorPropertiesService>();
+  auto const* tclk = lar::providerFrom<detinfo::DetectorClocksService>();
+  auto const& chStatus = art::ServiceHandle< lariov::ChannelStatusService >()->GetProvider();
 
-  art::Handle<std::vector<recob::Wire>> wireListHandle;
-  std::vector<art::Ptr<recob::Wire>> wires;
+  art::Handle < std::vector < recob::Wire > > wireListHandle;
+  std::vector < art::Ptr < recob::Wire > > wires;
   if (e.getByLabel(fWireProducerLabel, wireListHandle)) {
     art::fill_ptr_vector(wires, wireListHandle);
   }
 
-  auto simChannelHandle = e.getValidHandle<std::vector<sim::SimChannel>>("tpcrawdecoder:simpleSC");
+  auto simChannelHandle = e.getValidHandle<std::vector<sim::SimChannel>>(fSimulationProducerLabel);
 
+  // efficiency: according to each simulated energy deposit
   // ... Loop over simChannels
-  for (auto const& channel : (*simChannelHandle)) {
-
+  for ( auto const& channel : (*simChannelHandle) ){
+    
     // .. get simChannel channel number
     const raw::ChannelID_t ch1 = channel.Channel();
     if (chStatus.IsBad(ch1)) continue;
-    if (ch1 % 1000 == 0) mf::LogInfo("EvaluateROIEFF") << ch1;
+
+    if (ch1%1000 == 0) mf::LogInfo("EvaluateROIEFF")<<ch1;
     int view = geo->View(ch1);
     auto const& timeSlices = channel.TDCIDEMap();
-    for (auto const& timeSlice : timeSlices) {
+    
+    // time slice from simChannel is for individual tick
+    // group neighboring time slices into a "signal"
+    int tdctick_previous = -999;
+    double totalE = 0.;
+    double maxE = -999.;
+    int maxEtick = -999;
+    std::vector<int> signal_starttick;
+    std::vector<int> signal_endtick;
+    std::vector<double> signal_energydeposits;
+    std::vector<double> signal_energy_max;
+    std::vector<double> signal_max_tdctick;
 
-      auto const& energyDeposits = timeSlice.second;
+    for ( auto const& timeSlice : timeSlices ){
       auto const tpctime = timeSlice.first;
-      int tdctick = static_cast<int>(clockData.TPCTDC2Tick(double(tpctime)));
-      if (tdctick < 0 || tdctick > int(detProp.ReadOutWindowSize()) - 1) continue;
-      double totalE = 0;
-      for (auto const& energyDeposit : energyDeposits) {
-        totalE += energyDeposit.energy;
+      auto const& energyDeposits = timeSlice.second;
+      int tdctick = static_cast<int>(tclk->TPCTDC2Tick(double(tpctime)));
+      if(tdctick<0 || tdctick>int(detprop->ReadOutWindowSize())-1) continue;
+      
+      // for a time slice, there may exist more than one energy deposit.
+      double e_deposit = 0;
+      for ( auto const& energyDeposit : energyDeposits ){
+        e_deposit += energyDeposit.energy;
       }
-      h_energy[view]->Fill(totalE);
-      for (auto& wire : wires) {
-        if (wire->Channel() != ch1) continue;
-        const recob::Wire::RegionsOfInterest_t& signalROI = wire->SignalROI();
-        for (const auto& range : signalROI.get_ranges()) {
-          const auto& waveform = range.data();
-          raw::TDCtick_t roiFirstBinTick = range.begin_index();
-          if (tdctick >= roiFirstBinTick && tdctick < int(roiFirstBinTick + waveform.size())) {
-            h_energy_roi[view]->Fill(totalE);
-            break;
-          }
+
+      //std::cout<<e_deposit<<std::endl;
+
+      if (tdctick_previous == -999) {
+        signal_starttick.push_back(tdctick);
+        totalE += e_deposit;
+        maxE = e_deposit;
+        maxEtick = tdctick;
+      }
+      else if (tdctick - tdctick_previous != 1) {
+        signal_starttick.push_back(tdctick);
+        signal_endtick.push_back(tdctick_previous);
+        signal_energydeposits.push_back(totalE);
+        signal_energy_max.push_back(maxE);
+        signal_max_tdctick.push_back(maxEtick);
+        totalE = e_deposit;
+        maxE = e_deposit;
+        maxEtick = tdctick;
+      }
+      else if (tdctick - tdctick_previous == 1){
+        totalE += e_deposit;
+        if (maxE < e_deposit) {
+          maxE = e_deposit;
+          maxEtick = tdctick;
         }
       }
+      
+      tdctick_previous = tdctick;
+    
+    } // loop over timeSlices timeSlice
+    
+    signal_endtick.push_back(tdctick_previous); // for last one
+    signal_energydeposits.push_back(totalE); // for last one
+    signal_energy_max.push_back(maxE); // for last one
+    signal_max_tdctick.push_back(maxEtick); // for last one
+    
+    if (signal_starttick.size() == 0 || (signal_endtick.size()==1 && signal_endtick.back()==-999)) continue;
+
+    /*
+    // scan signals
+    cout << "signal_starttick.size(): " << signal_starttick.size() << endl;
+    cout << "signal_endtick.size(): " << signal_endtick.size() << endl;
+    cout << "signal_energydeposits.size(): " << signal_energydeposits.size() << endl;
+    cout << "signal_energy_max.size(): " << signal_energy_max.size() << endl;
+    cout << "signal_max_tdctick.size(): " << signal_max_tdctick.size() << endl;
+    for (size_t s=0; s<signal_starttick.size(); s++) {
+      cout << "....signal: " <<  s << endl;
+      cout << "start: " << signal_starttick[s] << " ; end: " << signal_endtick[s] << endl;
+      cout << "energy deposits: " << signal_energydeposits[s] << endl;
+      cout << "energy maxE: " << signal_energy_max[s] << endl;
+      cout << "energy maxE tdctick: " << signal_max_tdctick[s] << endl;
+    }
+    cout << "first tdc: " << signal_starttick[0] << "; last tdc: " << signal_endtick.back() << endl;
+    */
+
+    for (auto & wire : wires) {
+      if (wire->Channel() != ch1) continue;
+
+      const recob::Wire::RegionsOfInterest_t& signalROI = wire->SignalROI();
+
+      std::vector<float> vecADC = wire->Signal(); // a zero-padded full length vector filled with RoI signal.
+      
+      // loop over signals:
+      // a) if signal s is not in any ROI (including the case no ROI), fill h_energy with signal_energy_max[s];
+      // b) if signal s is in a ROI, check following signals that are also in this ROI, then use the maximum of signal_energy_max to fill h_energy and h_energy_roi. After this, the loop will skip to the signal that is not in this ROI.
+      for (size_t s=0; s<signal_starttick.size(); s++) {
+        // case a: signal is not in any ROI
+        bool IsSignalOutside = true;
+        for(const auto& range : signalROI.get_ranges()){
+          //const auto& waveform = range.data();
+          raw::TDCtick_t roiFirstBinTick = range.begin_index();
+          raw::TDCtick_t roiLastBinTick = range.end_index();
+
+          if (isSignalInROI(signal_starttick[s], signal_endtick[s], signal_max_tdctick[s], roiFirstBinTick, roiLastBinTick)) {
+            IsSignalOutside = false;
+            break;
+          }
+        } // loop over range
+        
+        if (IsSignalOutside) {
+          //cout << "This signal is not in any ROI: " << signal_starttick[s] << " -> " << signal_endtick[s] << endl; 
+          h_energy[view]->Fill(signal_energy_max[s]);
+          h1_tickdiff_max[view]->Fill(-99);
+          continue;
+        }
+        
+        // signal is in one ROI
+        for(const auto& range : signalROI.get_ranges()){
+          //const auto& waveform = range.data();
+          raw::TDCtick_t roiFirstBinTick = range.begin_index();
+          raw::TDCtick_t roiLastBinTick = range.end_index();
+
+          if (isSignalInROI(signal_starttick[s], signal_endtick[s], signal_max_tdctick[s], roiFirstBinTick, roiLastBinTick)) {
+            // maximum pulse height and postion for this ROI
+            double maxadc_sig = 0;
+            int maxadc_tick = -99;
+            for (int k=roiFirstBinTick; k<roiLastBinTick; k++) {
+              if (vecADC[k] > maxadc_sig) {
+                maxadc_sig = vecADC[k];
+                maxadc_tick = k;
+              }
+            }
+
+            double maxE_roi = -999.;
+            double maxE_roi_tick = -999.;
+
+            if (maxE_roi < signal_energy_max[s]) {
+              maxE_roi = signal_energy_max[s];
+              maxE_roi_tick = signal_max_tdctick[s];
+            }
+
+            // check the following signals in the same ROI
+            for (size_t s2=s+1; s2<signal_starttick.size(); s2++) {
+              if (isSignalInROI(signal_starttick[s2], signal_endtick[s2], signal_max_tdctick[s2], roiFirstBinTick, roiLastBinTick)) {
+                if (maxE_roi < signal_energy_max[s2]) {
+                  maxE_roi = signal_energy_max[s2];
+                  maxE_roi_tick = signal_max_tdctick[s2];
+                }
+                if (s2 == signal_starttick.size()-1) {
+                  s = s2;
+                }
+              }
+              else {
+                s = s2-1;
+                break;
+              }
+            } // loop over s2
+
+            // finish this ROI
+            h_energy[view]->Fill(maxE_roi);
+            h_energy_roi[view]->Fill(maxE_roi);
+            h1_tickdiff_max[view]->Fill(maxE_roi_tick - maxadc_tick);
+            break;
+          } // isSignalInROI
+        } // loop over range
+
+      } // loop over signals s
+    } // loop over wires wire
+  } // loop simChannels
+
+  // purity: # signals in ROI / (#signals in ROI + #non-signals in ROI). Because we only consider the maximum signal in the ROI, this is quivalent to purity of ( number of ROIs with signal / number of ROIs)
+  double roi_sig[3] = {0., 0., 0.}; // number of roi contains signal in an event
+  double roi_total[3] = {0., 0., 0.}; // number of roi in an event
+
+  for (auto & wire : wires) {
+    const raw::ChannelID_t wirechannel = wire->Channel();
+    if (chStatus.IsBad(wirechannel)) continue;
+   
+    int view = wire->View();
+
+    const recob::Wire::RegionsOfInterest_t& signalROI = wire->SignalROI();
+    
+    if (signalROI.get_ranges().empty()) continue;
+
+    std::vector<float> vecADC = wire->Signal(); // a zero-padded full length vector filled with RoI signal.
+
+    roi_total[view] += signalROI.get_ranges().size();
+    fCount_Roi_total[view] += signalROI.get_ranges().size();
+
+    for (const auto& range : signalROI.get_ranges()) {
+      bool IsSigROI = false;
+
+      raw::TDCtick_t roiFirstBinTick = range.begin_index();
+      raw::TDCtick_t roiLastBinTick = range.end_index();
+     
+      double maxadc_sig = -99.;
+      for (int k=roiFirstBinTick; k<roiLastBinTick; k++) {  
+        if (std::abs(vecADC[k]) > maxadc_sig) maxadc_sig = std::abs(vecADC[k]);
+      }
+      h1_roi_max[view]->Fill(maxadc_sig);
+      
+      // check simulation: ideally we could put this part outside loop over range to make the algorithm more efficient. However, as there are only one or two ROIs in a channel for most of cases, we keep this style to make the algorithm more readable. Also, signal information are kept here.
+      for (auto const& channel : (*simChannelHandle)) {
+        if (wirechannel != channel.Channel()) continue;
+
+        int tdctick_previous = -999;
+        double totalE = 0.;
+        double maxE = -999.;
+        int maxEtick = -999;
+        std::vector<int> signal_starttick;
+        std::vector<int> signal_endtick;
+        std::vector<double> signal_energydeposits;
+        std::vector<double> signal_energy_max;
+        std::vector<double> signal_max_tdctick;
+
+        auto const& timeSlices = channel.TDCIDEMap();
+
+        for ( auto const& timeSlice : timeSlices ){
+          auto const tpctime = timeSlice.first;
+          auto const& energyDeposits = timeSlice.second;
+          int tdctick = static_cast<int>(tclk->TPCTDC2Tick(double(tpctime)));
+          if(tdctick<0 || tdctick>int(detprop->ReadOutWindowSize())-1) continue;
+
+          double e_deposit = 0;
+          for ( auto const& energyDeposit : energyDeposits ){
+            e_deposit += energyDeposit.energy;
+          }
+
+          if (tdctick_previous == -999) {
+            signal_starttick.push_back(tdctick);
+            totalE += e_deposit;
+            maxE = e_deposit;
+            maxEtick = tdctick;
+          }
+          else if (tdctick - tdctick_previous != 1) {
+            signal_starttick.push_back(tdctick);
+            signal_endtick.push_back(tdctick_previous);
+            signal_energydeposits.push_back(totalE);
+            signal_energy_max.push_back(maxE);
+            signal_max_tdctick.push_back(maxEtick);
+            totalE = e_deposit;
+            maxE = e_deposit;
+            maxEtick = tdctick;
+          }
+          else if (tdctick - tdctick_previous == 1){
+            totalE += e_deposit;
+            if (maxE < e_deposit) {
+              maxE = e_deposit;
+              maxEtick = tdctick;
+            }
+          }
+
+          tdctick_previous = tdctick;
+
+        } // loop over timeSlices timeSlice
+
+        signal_endtick.push_back(tdctick_previous); // for last one
+        signal_energydeposits.push_back(totalE); // for last one
+        signal_energy_max.push_back(maxE); // for last one
+        signal_max_tdctick.push_back(maxEtick); // for last one
+        
+        if (signal_starttick.size() == 0 || (signal_endtick.size()==1 && signal_endtick.back()==-999)) continue;
+
+        // check if signal/signals in this ROI
+        for (size_t s=0; s<signal_starttick.size(); s++) {
+          if (isSignalInROI(signal_starttick[s], signal_endtick[s], signal_max_tdctick[s], roiFirstBinTick, roiLastBinTick)) {
+            IsSigROI = true;
+            break;
+          }
+        } // loop over s
+      } // loop simChannels
+      
+      h_roi[view]->Fill(0); // total roi
+      if (IsSigROI) {
+        roi_sig[view] += 1. ;
+        fCount_Roi_sig[view] += 1;
+        h_roi[view]->Fill(1); // sig roi
+        h1_roi_max_sim[view]->Fill(maxadc_sig);
+      }
+    } // loop ranges of signalROI
+  } // loop wires
+  
+  // purity of each plane for each event
+  for (int i=0; i<3; i++) {
+    if (roi_total[i]) {
+      double purity = roi_sig[i]/roi_total[i];
+      if (purity==1) purity = 1. -1.e-6;
+      h_purity[i]->Fill(purity);
     }
   }
-}
-
-void
-nnet::EvaluateROIEff::beginJob()
-{
-
-  art::ServiceHandle<art::TFileService const> tfs;
-
-  for (int i = 0; i < 3; ++i) {
-    h_energy[i] =
-      tfs->make<TH1D>(Form("h_energy_%d", i), Form("Plane %d; Energy (MeV);", i), 100, 0, 1);
-    h_energy_roi[i] =
-      tfs->make<TH1D>(Form("h_energy_roi_%d", i), Form("Plane %d; Energy (MeV);", i), 100, 0, 1);
+  
+  // combined purity for each event
+  if (roi_total[0]+roi_total[1]+roi_total[2]) {
+    double purity = (roi_sig[0]+roi_sig[1]+roi_sig[2])/(roi_total[0]+roi_total[1]+roi_total[2]);
+    if (purity==1) purity = 1. -1.e-6;
+    h_purity_all->Fill(purity);
   }
 }
 
-void
-nnet::EvaluateROIEff::endJob()
-{
+void nnet::EvaluateROIEff::beginJob(){
 
   art::ServiceHandle<art::TFileService const> tfs;
 
-  for (int i = 0; i < 3; ++i) {
-    std::cout << i << " " << h_energy[i]->GetNbinsX() << " " << h_energy_roi[i]->GetNbinsX()
-              << std::endl;
-    if (TEfficiency::CheckConsistency(*(h_energy[i]), *(h_energy_roi[i]))) {
+  for (int i = 0; i<3; ++i){
+    h_energy[i] = tfs->make<TH1D>(Form("h_energy_%d",i), Form("Plane %d; Energy (MeV);",i), 100,0,1);
+    h_energy_roi[i] = tfs->make<TH1D>(Form("h_energy_roi_%d",i), Form("Plane %d; Energy (MeV);",i), 100,0,1);
+
+    h_purity[i] = tfs->make<TH1D>(Form("h_purity_%d",i), Form("Plane %d; Purity;",i), 20,0,1);
+    h_roi[i] = tfs->make<TH1D>(Form("h_roi_%d",i), Form("Plane %d; Purity;",i), 5,0,5); // index 0: total rois; index 1: total sig rois
+    
+    h1_roi_max[i] = tfs->make<TH1D>(Form("h1_roi_max_%d",i), Form("Plane %d; Max adc;", i), 50,0,50);
+    h1_roi_max_sim[i] = tfs->make<TH1D>(Form("h1_roi_max_sim_%d",i), Form("Plane %d; Max adc;", i), 50,0,50);
+
+    h1_tickdiff_max[i] = tfs->make<TH1D>(Form("h1_tickdiff_max_%d",i), Form("Plane %d; tick diff (maxE - max pulse);", i), 100,-50,50);
+  }
+
+  h_purity_all = tfs->make<TH1D>("h_purity_all", "All Planes; Purity;", 20,0,1);
+}
+
+void nnet::EvaluateROIEff::endJob(){
+  art::ServiceHandle<art::TFileService const> tfs;
+
+  for (int i = 0; i<3; ++i){
+    std::cout<<i<<" "<<h_energy[i]->GetNbinsX()<<" "<<h_energy_roi[i]->GetNbinsX()<<std::endl;
+    if(TEfficiency::CheckConsistency(*(h_energy_roi[i]), *(h_energy[i]))){
       eff_energy[i] = tfs->make<TEfficiency>(*(h_energy_roi[i]), *(h_energy[i]));
-      eff_energy[i]->Write(Form("eff_energy_%d", i));
+      eff_energy[i]->Write(Form("eff_energy_%d",i));
     }
   }
+
+  // purity
+  for (int i=0; i<3; ++i) {
+    if (fCount_Roi_total[i]==0) continue;
+    cout << "\nplane : " << i << endl;
+    cout << "ROI purity (a) sig roi/total rois: " << fCount_Roi_sig[i] << "/" << fCount_Roi_total[i] << " = " << 1.0*fCount_Roi_sig[i]/fCount_Roi_total[i] << endl;
+
+    cout << "ROI purity (b) from histogram: sig/total: " << h_roi[i]->GetBinContent(2) << "/" << h_roi[i]->GetBinContent(1) << " = " << 1.0*(h_roi[i]->GetBinContent(2))/(h_roi[i]->GetBinContent(1)) << endl;
+  }
+
+  cout << "\nROI combined purity (all planes) (a) sig roi/total rois: " << fCount_Roi_sig[0]+ fCount_Roi_sig[1] + fCount_Roi_sig[2]<< "/" << fCount_Roi_total[0]+fCount_Roi_total[1] + fCount_Roi_total[2] << " = " << 1.0*(fCount_Roi_sig[0]+fCount_Roi_sig[1]+fCount_Roi_sig[2])/(fCount_Roi_total[0]+fCount_Roi_total[1]+fCount_Roi_total[2]) << endl;
+
+  cout << "ROI combined purity (all planes) (b) from histogram: " << h_roi[0]->GetBinContent(2) + h_roi[1]->GetBinContent(2) + h_roi[2]->GetBinContent(2) << "/" << h_roi[0]->GetBinContent(1) + h_roi[1]->GetBinContent(1) + h_roi[2]->GetBinContent(1) << " = "<< 1.0*(h_roi[0]->GetBinContent(2) + h_roi[1]->GetBinContent(2) + h_roi[2]->GetBinContent(2)) / (h_roi[0]->GetBinContent(1) + h_roi[1]->GetBinContent(1) + h_roi[2]->GetBinContent(1)) << endl;
+}
+
+bool nnet::EvaluateROIEff::isSignalInROI (int starttick, int endtick, int maxtick, int roistart, int roiend) {
+  // For a signal in the ROI, two cases are considered: 
+  //   (i) signal is totally in the ROI
+  //   (ii) signal is partially in the ROI
+  // Equivalently, we can just check whether the maxtick is in the ROI (simple one). We keep the above algorithm here, too.
+  bool IsInROI = false;
+  /*
+  // signal is totally in ROI
+  if (starttick>=roistart && endtick<roiend) {
+    IsInROI = true;
+  }
+  // signal is partial in ROI
+  else if ( (starttick<roistart && roistart<=endtick) ||
+            (starttick<roiend && roiend <= endtick) ) {
+    if (roistart<=maxtick && maxtick<roiend) {
+      IsInROI = true;
+    }
+  }
+  */
+
+  if (roistart<=maxtick && maxtick<roiend) {
+    IsInROI = true;
+  }
+
+  return IsInROI;
 }
 
 DEFINE_ART_MODULE(nnet::EvaluateROIEff)

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/RawWaveformDump_module.cc
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/RawWaveformDump_module.cc
@@ -386,8 +386,8 @@ nnet::RawWaveformDump::analyze(art::Event const& evt)
         auto const& energyDeposits = timeSlice.second;
         auto const tpctime = timeSlice.first;
         unsigned int tdctick = static_cast<unsigned int>(clockData.TPCTDC2Tick(double(tpctime)));
-        if (tdctick != tpctime)
-          std::cout << "tpctime: " << tpctime << ", tdctick: " << tdctick << std::endl;
+        //if (tdctick != tpctime)
+        //  std::cout << "tpctime: " << tpctime << ", tdctick: " << tdctick << std::endl;
         if (tdctick < 0 || tdctick > (dataSize - 1)) continue;
 
         // ... Loop over all energy depositions in this tick

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/RawWaveformDump_module.cc
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/RawWaveformDump_module.cc
@@ -4,6 +4,11 @@
 //
 //  mwang@fnal.gov
 //  tjyang@fnal.gov
+//  wwu@fnal.gov
+//  
+//  Include the following options:
+//    a) RawDigit or WireProducer
+//    b) save full waveform or short waveform
 //
 //////////////////////////////////////////////
 
@@ -30,11 +35,15 @@
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardataobj/RawData/RawDigit.h"
 #include "lardataobj/RawData/raw.h"
+#include "lardataobj/RecoBase/Wire.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/Simulation/SimChannel.h"
 #include "larsim/MCCheater/ParticleInventoryService.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
+
+#include "larevt/CalibrationDBI/Interface/ChannelStatusService.h"
+#include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h"
 
 // DUNETPC specific includes
 //#include "dune/DAQTriggerSim/TriggerDataProducts/TriggerTypes.h"
@@ -43,6 +52,7 @@
 //#include "dune/DuneInterface/SimChannelExtractService.h"
 
 #include "c2numpy.h"
+#include "TRandom.h"
 
 using std::cout;
 using std::endl;
@@ -85,9 +95,11 @@ public:
 private:
   std::string fDumpWaveformsFileName;
 
-  std::string
-    fSimulationProducerLabel; ///< The name of the producer that tracked simulated particles through the detector
+  std::string fSimulationProducerLabel; ///< The name of the producer that tracked simulated particles through the detector
   std::string fDigitModuleLabel; ///< module that made digits
+  std::string fWireProducerLabel;
+  bool fUseFullWaveform;
+  unsigned int fShortWaveformSize;
 
   std::string fSelectGenLabel;
   std::string fSelectProcID;
@@ -154,6 +166,9 @@ nnet::RawWaveformDump::RawWaveformDump(fhicl::ParameterSet const& p)
   , fDumpWaveformsFileName(p.get<std::string>("DumpWaveformsFileName", "dumpwaveforms"))
   , fSimulationProducerLabel(p.get<std::string>("SimulationProducerLabel", "largeant"))
   , fDigitModuleLabel(p.get<std::string>("DigitModuleLabel", "daq"))
+  , fWireProducerLabel(p.get<std::string>("WireProducerLabel"))
+  , fUseFullWaveform(p.get<bool>("UseFullWaveform",true))
+  , fShortWaveformSize(p.get<unsigned int>("ShortWaveformSize"))
   , fSelectGenLabel(p.get<std::string>("SelectGenLabel", "ANY"))
   , fSelectProcID(p.get<std::string>("SelectProcID", "ANY"))
   , fSelectPDGCode(p.get<int>("SelectPDGCode", 0))
@@ -165,6 +180,15 @@ nnet::RawWaveformDump::RawWaveformDump(fhicl::ParameterSet const& p)
   , fSaveSignal(p.get<bool>("SaveSignal", true))
 {
   if (std::getenv("PROCESS")) { fDumpWaveformsFileName += string(std::getenv("PROCESS")) + "-"; }
+
+  if (fDigitModuleLabel.empty() && fWireProducerLabel.empty()){
+    throw cet::exception("RawWaveformDump") << "Both DigitModuleLabel and WireProducerLabel are empty";
+  }
+
+  if ((!fDigitModuleLabel.empty()) && (!fWireProducerLabel.empty())){
+    throw cet::exception("RawWaveformDump") << "Only one of DigitModuleLabel and WireProducerLabel should be set";
+  }
+
   //this->reconfigure(p);
 }
 
@@ -219,7 +243,7 @@ nnet::RawWaveformDump::beginJob()
     c2numpy_addcolumn(&npywriter, name.str().c_str(), C2NUMPY_UINT16);
   }
 
-  for (unsigned int i = 0; i < detProp.ReadOutWindowSize(); i++) {
+  for (unsigned int i = 0; i < (fUseFullWaveform ? detProp.ReadOutWindowSize() : fShortWaveformSize); i++) {
     std::ostringstream name;
     name << "tck_" << i;
     c2numpy_addcolumn(&npywriter, name.str().c_str(), C2NUMPY_INT16);
@@ -242,31 +266,64 @@ nnet::RawWaveformDump::analyze(art::Event const& evt)
 
   // ... Read in the digit List object(s).
   art::Handle<std::vector<raw::RawDigit>> digitVecHandle;
-  evt.getByLabel(fDigitModuleLabel, digitVecHandle);
+  std::vector< art::Ptr<raw::RawDigit>> rawdigitlist;
+  if (evt.getByLabel(fDigitModuleLabel, digitVecHandle)){
+    art::fill_ptr_vector(rawdigitlist, digitVecHandle);
+  }
 
-  if (!digitVecHandle->size()) return;
+  // ... Read in the wire List object(s).
+  art::Handle< std::vector<recob::Wire> > wireListHandle;
+  std::vector<art::Ptr<recob::Wire> > wirelist;
+  if (evt.getByLabel(fWireProducerLabel, wireListHandle)) {
+    art::fill_ptr_vector(wirelist, wireListHandle);
+  }
+
+  if (rawdigitlist.empty() && wirelist.empty())  return;
+  if (rawdigitlist.size() && wirelist.size())  return;
+  
+  // channel status
+  lariov::ChannelStatusProvider const& channelStatus
+    = art::ServiceHandle<lariov::ChannelStatusService const>()->GetProvider();
 
   auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
   auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
 
   // ... Use the handle to get a particular (0th) element of collection.
-  art::Ptr<raw::RawDigit> digitVec0(digitVecHandle, 0);
-  unsigned int dataSize = digitVec0->Samples(); //size of raw data vectors
+  unsigned int dataSize;
+  if (rawdigitlist.size()) {
+    art::Ptr<raw::RawDigit> digitVec0(digitVecHandle, 0);
+    dataSize = digitVec0->Samples(); //size of raw data vectors
+  }
+  else {
+    dataSize = (wirelist[0]->Signal()).size();
+  }
   if (dataSize != detProp.ReadOutWindowSize()) {
     std::cout << "!!!!! Bad dataSize: " << dataSize << std::endl;
     return;
   }
 
-  std::vector<short> rawadc(dataSize); // vector to hold uncompressed adc values later
+  //std::vector<short> rawadc(dataSize); // vector to hold uncompressed adc values later
 
   // ... Build a map from channel number -> rawdigitVec
   std::map<raw::ChannelID_t, art::Ptr<raw::RawDigit>> rawdigitMap;
   raw::ChannelID_t chnum = raw::InvalidChannelID; // channel number
-  for (size_t rdIter = 0; rdIter < digitVecHandle->size(); ++rdIter) {
-    art::Ptr<raw::RawDigit> digitVec(digitVecHandle, rdIter);
-    chnum = digitVec->Channel();
-    if (chnum == raw::InvalidChannelID) continue;
-    rawdigitMap[chnum] = digitVec;
+  if (rawdigitlist.size()) {
+    for (size_t rdIter = 0; rdIter < digitVecHandle->size(); ++rdIter) {
+      art::Ptr<raw::RawDigit> digitVec(digitVecHandle, rdIter);
+      chnum = digitVec->Channel();
+      if (chnum == raw::InvalidChannelID) continue;
+      rawdigitMap[chnum] = digitVec;
+    }
+  }
+  // ... Build a map from channel number -> wire
+  std::map <raw::ChannelID_t, art::Ptr<recob::Wire>> wireMap;
+  if (wirelist.size()) {
+    for (size_t ich=0; ich<wirelist.size(); ++ich) {
+      art::Ptr<recob::Wire> wire = wirelist[ich];
+      chnum = wire->Channel();
+      if (chnum == raw::InvalidChannelID) continue;
+      wireMap[chnum] = wire;
+    }
   }
 
   // ... Read in MC particle list
@@ -414,10 +471,28 @@ nnet::RawWaveformDump::analyze(art::Event const& evt)
         std::map<raw::ChannelID_t, std::map<int, WireSigInfo>>::iterator itchn;
         itchn = Ch2TrkWSInfoMap.find(chnum);
         if (itchn != Ch2TrkWSInfoMap.end()) {
-          auto search = rawdigitMap.find(chnum);
-          if (search == rawdigitMap.end()) continue;
-          art::Ptr<raw::RawDigit> rawdig = (*search).second;
-          raw::Uncompress(rawdig->ADCs(), rawadc, rawdig->GetPedestal(), rawdig->Compression());
+          
+          std::vector<short> adcvec(dataSize); // vector to hold zero-padded full waveform
+
+          if (rawdigitlist.size()) {
+            auto search = rawdigitMap.find(chnum);
+            if (search == rawdigitMap.end()) continue;
+            art::Ptr<raw::RawDigit> rawdig = (*search).second;
+            std::vector<short> rawadc(dataSize);  // vector to hold uncompressed adc values later
+            raw::Uncompress(rawdig->ADCs(), rawadc, rawdig->GetPedestal(), rawdig->Compression());
+            for (size_t j=0; j<rawadc.size(); ++j) {
+              adcvec[j] = rawadc[j] - rawdig->GetPedestal();
+            }
+          }
+          else if (wirelist.size()) {
+            auto search = wireMap.find(chnum);
+            if (search == wireMap.end()) continue;
+            art::Ptr<recob::Wire> wire = (*search).second;
+            const auto & signal = wire->Signal();
+            for (size_t j=0; j<adcvec.size(); ++j) {
+              adcvec[j] = signal[j];
+            }
+          }
 
           c2numpy_uint32(&npywriter, evt.id().event());
           c2numpy_uint32(&npywriter, chnum);
@@ -426,6 +501,12 @@ nnet::RawWaveformDump::analyze(art::Event const& evt)
                          itchn->second.size()); // size of Trk2WSInfoMap, or number of peaks
 
           // .. write out info for each peak
+          // a full waveform has at least one peak; the output will save up to 5 peaks (if there is only 1 peak, will fill the other 4 with 0);
+          // for fShortWaveformSize: only use the first peak's start_tick
+          
+          int start_tick = -1;
+          int end_tick = -1;
+
           unsigned int icnt = 0;
           for (auto const& it : itchn->second) {
             c2numpy_int32(&npywriter, it.first);                  // trackid
@@ -434,8 +515,34 @@ nnet::RawWaveformDump::analyze(art::Event const& evt)
             c2numpy_string(&npywriter, it.second.procid.c_str()); // procid
             c2numpy_float32(&npywriter, it.second.edep);          // edepo
             c2numpy_uint32(&npywriter, it.second.numel);          // numelec
-            c2numpy_uint16(&npywriter, it.second.tdcmin);         // stck1
-            c2numpy_uint16(&npywriter, it.second.tdcmax);         // stc2
+
+            if (fUseFullWaveform) {
+              c2numpy_uint16(&npywriter, it.second.tdcmin);         // stck1
+              c2numpy_uint16(&npywriter, it.second.tdcmax);         // stc2
+            }
+            else {
+              // select ticks to save
+              if (icnt == 0) {
+                start_tick = it.second.tdcmin - it.second.tdcmin % fShortWaveformSize;
+                if (it.second.tdcmin-start_tick< 30) start_tick = start_tick-30;
+                if (it.second.tdcmax - start_tick >120) start_tick = it.second.tdcmax-120;
+                end_tick = start_tick + fShortWaveformSize;
+
+                if (end_tick>=2048) {
+                  end_tick = 2048;
+                  start_tick = end_tick - fShortWaveformSize;
+                }
+
+                if (start_tick<0) {
+                  start_tick = 0;
+                  end_tick = start_tick + fShortWaveformSize;
+                }
+              }
+
+              c2numpy_uint16(&npywriter,  it.second.tdcmin-start_tick);         // stck1
+              c2numpy_uint16(&npywriter,  it.second.tdcmax-start_tick);         // stc2
+            }
+
             icnt++;
             if (icnt == 5) break;
           }
@@ -453,9 +560,17 @@ nnet::RawWaveformDump::analyze(art::Event const& evt)
           }
 
           // .. now write out the ADC values
-          for (unsigned int itck = 0; itck < dataSize; ++itck) {
-            rawadc[itck] -= rawdig->GetPedestal();
-            c2numpy_int16(&npywriter, rawadc[itck]);
+          if (fUseFullWaveform) {
+            for ( unsigned int itck=0; itck<dataSize; ++itck ){
+              c2numpy_int16(&npywriter, adcvec[itck]);
+            }
+          }
+          else {
+            if (start_tick==-1) return;
+
+            for ( unsigned int itck=start_tick; itck<(start_tick+fShortWaveformSize); ++itck ){
+              c2numpy_int16(&npywriter, adcvec[itck]);
+            }
           }
         }
       }
@@ -469,16 +584,37 @@ nnet::RawWaveformDump::analyze(art::Event const& evt)
       signalMap[channel.Channel()] = true;
     }
 
-    std::vector<short> rawadc(dataSize); // vector to hold uncompressed adc values later
+    for (size_t rdIter = 0; rdIter < (rawdigitlist.empty() ? wirelist.size() : rawdigitlist.size()); ++rdIter) {
 
-    for (size_t rdIter = 0; rdIter < digitVecHandle->size(); ++rdIter) {
-      art::Ptr<raw::RawDigit> digitVec(digitVecHandle, rdIter);
-      if (signalMap[digitVec->Channel()]) continue;
-      if (geo::PlaneGeo::ViewName(fgeom->View(digitVec->Channel())) != fPlaneToDump[0]) continue;
-      raw::Uncompress(digitVec->ADCs(), rawadc, digitVec->GetPedestal(), digitVec->Compression());
-      c2numpy_uint32(&npywriter, evt.id().event());
-      c2numpy_uint32(&npywriter, digitVec->Channel());
-      c2numpy_string(&npywriter, geo::PlaneGeo::ViewName(fgeom->View(digitVec->Channel())).c_str());
+      std::vector<short> adcvec(dataSize);  // vector to wire adc values
+
+      if (rawdigitlist.size()) {
+        art::Ptr<raw::RawDigit> digitVec(digitVecHandle, rdIter);
+        if (signalMap[digitVec->Channel()]) continue;
+
+        std::vector<short> rawadc(dataSize);  // vector to hold uncompressed adc values later
+        if (geo::PlaneGeo::ViewName(fgeom->View(digitVec->Channel())) != fPlaneToDump[0]) continue;
+        raw::Uncompress(digitVec->ADCs(), rawadc, digitVec->GetPedestal(), digitVec->Compression());        for (size_t j=0; j<rawadc.size(); ++j) {
+          adcvec[j] = rawadc[j] - digitVec->GetPedestal();
+        }
+        c2numpy_uint32(&npywriter, evt.id().event());
+        c2numpy_uint32(&npywriter, digitVec->Channel());
+        c2numpy_string(&npywriter, geo::PlaneGeo::ViewName(fgeom->View(digitVec->Channel())).c_str());
+      }
+      else if (wirelist.size()) {
+        art::Ptr<recob::Wire> wire = wirelist[rdIter];
+        if (signalMap[wire->Channel()]) continue;
+        if (channelStatus.IsBad(wire->Channel())) continue;
+        if(geo::PlaneGeo::ViewName(fgeom->View(wire->Channel()))!=fPlaneToDump[0]) continue;
+        const auto & signal = wire->Signal();
+        for (size_t j=0; j<adcvec.size(); ++j) {
+          adcvec[j] = signal[j];
+        }
+        c2numpy_uint32(&npywriter, evt.id().event());
+        c2numpy_uint32(&npywriter, wire->Channel());
+        c2numpy_string(&npywriter, geo::PlaneGeo::ViewName(fgeom->View(wire->Channel())).c_str());
+      }
+
       c2numpy_uint16(&npywriter, 0); //number of peaks
       for (unsigned int i = 0; i < 5; ++i) {
         c2numpy_int32(&npywriter, 0);
@@ -490,10 +626,19 @@ nnet::RawWaveformDump::analyze(art::Event const& evt)
         c2numpy_uint16(&npywriter, 0);
         c2numpy_uint16(&npywriter, 0);
       }
-      for (unsigned int itck = 0; itck < dataSize; ++itck) {
-        rawadc[itck] -= digitVec->GetPedestal();
-        c2numpy_int16(&npywriter, rawadc[itck]);
+
+      if (fUseFullWaveform) {
+        for ( unsigned int itck=0; itck<dataSize; ++itck ){
+          c2numpy_int16(&npywriter, adcvec[itck]);
+        }
       }
+      else {
+        int start_tick = int((2048-fShortWaveformSize)*gRandom->Uniform(0,1));
+        for ( unsigned int itck=start_tick; itck<(start_tick+fShortWaveformSize); ++itck ){
+          c2numpy_int16(&npywriter, adcvec[itck]);
+        }
+      }
+
       ++noisechancount;
     }
     std::cout << "Total number of noise channels " << noisechancount << std::endl;

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/waveformroifinder.fcl
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/waveformroifinder.fcl
@@ -1,69 +1,36 @@
 BEGIN_PROLOG
 
+tool_WaveformRecog:
+{
+    NNetModelFile: "CnnModels/lightmodel112.pb"
+    NNetOutputPattern: [
+        "cnn_output",
+        "dense_3"
+    ]
+    #TrtisModelName:     "lightmodel112"
+    #TrtisURL:          "localhost:8001"
+    #TrtisModelVersion:  -1
+    #TrtisVerbose:      true
+    WaveformSize:       6000
+    ScanWindowSize:     200
+    StrideLength:       150
+    MeanFilename:       "CnnModels/wvrec-mean.txt"
+    ScaleFilename:      "CnnModels/wvrec-scale.txt"
+    CnnPredCut:         0.5
+    tool_type: "WaveformRecogTf"
+}
+
+
 standard_waveformroifinder:
 {
     module_type: "WaveformRoiFinder"
-    NPlanes:         3
-    WaveformSize:    6000
-    RawProducerLabel:   ""
     WireProducerLabel:  "caldata:dataprep"
 
-    WaveformRecogPlane0: {
-       NNetModelFile: "CnnModels/lightmodel112.pb"
-       NNetOutputPattern: [
-          "cnn_output",
-          "dense_3"
-       ]
-       #TrtisModelName:     "lightmodel112"
-       #TrtisURL:          "localhost:8001"
-       #TrtisModelVersion:  -1
-       #TrtisVerbose:      true
-       WaveformSize:       6000
-       ScanWindowSize:     200
-       StrideLength:       150
-       MeanFilename:       "CnnModels/wvrec-mean.txt"
-       ScaleFilename:      "CnnModels/wvrec-scale.txt"
-       CnnPredCut:         0.5
-       tool_type: "WaveformRecogTf"
-    }
-
-    WaveformRecogPlane1: {
-       NNetModelFile: "CnnModels/lightmodel112.pb"
-       NNetOutputPattern: [
-          "cnn_output",
-          "dense_3"
-       ]
-       #TrtisModelName:     "lightmodel112"
-       #TrtisURL:          "localhost:8001"
-       #TrtisModelVersion:  -1
-       #TrtisVerbose:      true
-       WaveformSize:       6000
-       ScanWindowSize:     200
-       StrideLength:       150
-       MeanFilename:       "CnnModels/wvrec-mean.txt"
-       ScaleFilename:      "CnnModels/wvrec-scale.txt"
-       CnnPredCut:         0.5
-       tool_type: "WaveformRecogTf"
-    }
-
-    WaveformRecogPlane2: {
-       NNetModelFile: "CnnModels/lightmodel112.pb"
-       NNetOutputPattern: [
-          "cnn_output",
-          "dense_3"
-       ]
-       #TrtisModelName:     "lightmodel112"
-       #TrtisURL:          "localhost:8001"
-       #TrtisModelVersion:  -1
-       #TrtisVerbose:      true
-       WaveformSize:       6000
-       ScanWindowSize:     200
-       StrideLength:       150
-       MeanFilename:       "CnnModels/wvrec-mean.txt"
-       ScaleFilename:      "CnnModels/wvrec-scale.txt"
-       CnnPredCut:         0.5
-       tool_type: "WaveformRecogTf"
-    }
+    WaveformRecogs: [
+        @local::tool_WaveformRecog,
+        @local::tool_WaveformRecog,
+        @local::tool_WaveformRecog
+    ] 
 }
 
 END_PROLOG

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/waveformroifinder.fcl
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/waveformroifinder.fcl
@@ -3,8 +3,50 @@ BEGIN_PROLOG
 standard_waveformroifinder:
 {
     module_type: "WaveformRoiFinder"
+    NPlanes:         3
+    WaveformSize:    6000
+    RawProducerLabel:   ""
     WireProducerLabel:  "caldata:dataprep"
-    WaveformRecog: {
+
+    WaveformRecogPlane0: {
+       NNetModelFile: "CnnModels/lightmodel112.pb"
+       NNetOutputPattern: [
+          "cnn_output",
+          "dense_3"
+       ]
+       #TrtisModelName:     "lightmodel112"
+       #TrtisURL:          "localhost:8001"
+       #TrtisModelVersion:  -1
+       #TrtisVerbose:      true
+       WaveformSize:       6000
+       ScanWindowSize:     200
+       StrideLength:       150
+       MeanFilename:       "CnnModels/wvrec-mean.txt"
+       ScaleFilename:      "CnnModels/wvrec-scale.txt"
+       CnnPredCut:         0.5
+       tool_type: "WaveformRecogTf"
+    }
+
+    WaveformRecogPlane1: {
+       NNetModelFile: "CnnModels/lightmodel112.pb"
+       NNetOutputPattern: [
+          "cnn_output",
+          "dense_3"
+       ]
+       #TrtisModelName:     "lightmodel112"
+       #TrtisURL:          "localhost:8001"
+       #TrtisModelVersion:  -1
+       #TrtisVerbose:      true
+       WaveformSize:       6000
+       ScanWindowSize:     200
+       StrideLength:       150
+       MeanFilename:       "CnnModels/wvrec-mean.txt"
+       ScaleFilename:      "CnnModels/wvrec-scale.txt"
+       CnnPredCut:         0.5
+       tool_type: "WaveformRecogTf"
+    }
+
+    WaveformRecogPlane2: {
        NNetModelFile: "CnnModels/lightmodel112.pb"
        NNetOutputPattern: [
           "cnn_output",


### PR DESCRIPTION
- update EvaluateROIEff_module.cc, more accurate evaluation on efficiency and purity;
- update RawWaveformDump_module.cc to have options use either RawDigit or WireProducer waveform, to save full waveform or short waveform;
- update WaveformRoiFinder_module.cc and waveformroifinder.fcl to use cnnroi network for each plane separately, add an option to set number of planes.
