### PR TITLE
PointIdTrainingData: write and dispose of histograms as soon as possible

### DIFF
--- a/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/PointIdTrainingData_module.cc
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/Modules/PointIdTrainingData_module.cc
@@ -34,6 +34,17 @@
 #include "TH2F.h" // ADC and deposit maps
 #include "TH2I.h" // PDG+vertex info map
 
+namespace {
+  template <typename Hist>
+  void writeAndDelete(Hist*& hist) {
+    if (!hist) return;
+    hist->Write();
+    delete hist;
+    hist = nullptr;
+  } // writeAndDelete()
+} // local namespace
+
+
 namespace nnet {
 
   class PointIdTrainingData : public art::EDAnalyzer {
@@ -84,6 +95,7 @@ namespace nnet {
     bool fCrop; /// crop data to event (set to false when dumping noise!)
 
     geo::GeometryCore const* fGeometry;
+    
   };
 
   //-----------------------------------------------------------------------
@@ -188,6 +200,11 @@ namespace nnet {
               }
             }
           }
+          
+          writeAndDelete(rawHist);
+          writeAndDelete(depHist);
+          writeAndDelete(pdgHist);
+          
         }
         else {
           std::ostringstream ss1;


### PR DESCRIPTION
This is a workaround to [Redmine issue #25476](https://cdcvs.fnal.gov/redmine/issues/25476).

Basically the module `PointIdTrainingData` creates several histograms per event, and the commit is forcing ROOT to write them to file at the end of each event instead of "automatically" at the end of the job.
This may conflict with _art_ `TFileService` or ROOT paradigms, so I recommend a review for them.

The submitter of the support request was @yangtj207.