### PR TITLE
Fix unused-result Clang compilation warning

### DIFF
--- a/larrecodnn/ImagePatternAlgs/Tensorflow/TF/CMakeLists.txt
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/TF/CMakeLists.txt
@@ -1,8 +1,5 @@
 include_directories( $ENV{TENSORFLOW_INC}/absl )
 
-# the code in tf::Graph::~Graph() should be inspected 
-cet_add_compiler_flags(CXX -Wno-unused-result)
-
 art_make(
           LIB_LIBRARIES
 			${FHICLCPP}
@@ -15,4 +12,3 @@ art_make(
 
 install_headers()
 install_source()
-

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
@@ -91,7 +91,7 @@ tf::Graph::Graph(const char* graph_file_name, const std::vector<std::string> & o
 
 tf::Graph::~Graph()
 {
-    fSession->Close();
+    fSession->Close().IgnoreError();
     delete fSession;
 }
 // -------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses a compilation warning/error related to a discarded value as described [here](https://cdcvs.fnal.gov/redmine/issues/25871).  The solution adopted here follows the tensorflow-suggested method for suppressing this type of error.