### PR TITLE
added TritonAllowedTries fhicl parameter

### DIFF
--- a/larrecodnn/ImagePatternAlgs/ToolInterfaces/IPointIdAlg.h
+++ b/larrecodnn/ImagePatternAlgs/ToolInterfaces/IPointIdAlg.h
@@ -55,6 +55,10 @@ namespace PointIdAlgTools {
         Name("TritonVerbose"),
         Comment("Verbosity switch for Nvidia Triton inference server client"),
         false};
+      fhicl::Atom<unsigned> TritonAllowedTries{
+        Name("TritonAllowedTries"),
+        Comment("Number of allowed attempts for Nvidia Triton inference server client"),
+        1};
     };
     virtual ~IPointIdAlg() noexcept = default;
 

--- a/larrecodnn/ImagePatternAlgs/Triton/Tools/PointIdAlgSonicTriton_tool.cc
+++ b/larrecodnn/ImagePatternAlgs/Triton/Tools/PointIdAlgSonicTriton_tool.cc
@@ -44,6 +44,7 @@ namespace PointIdAlgTools {
     fTritonURL = table().TritonURL();
     fTritonVerbose = table().TritonVerbose();
     fTritonModelVersion = table().TritonModelVersion();
+    fTritonAllowedTries = table().TritonAllowedTries();
 
     // ... Create parameter set for Triton inference client
     fhicl::ParameterSet TritonPset;


### PR DESCRIPTION
Added this fhicl parameter to PointIdAlg so user can specify total number of inference attempts before giving up.  This is urgently needed by the ProtoDUNE production scaling tests being done now using the GCP inference server.