### PR TITLE
First commit of tf_graph to use SavedModelBundle

### DIFF
--- a/larrecodnn/ImagePatternAlgs/Modules/waveformroifinder.fcl
+++ b/larrecodnn/ImagePatternAlgs/Modules/waveformroifinder.fcl
@@ -17,6 +17,8 @@ tool_WaveformRecog:
     MeanFilename:       "CnnModels/wvrec-mean.txt"
     ScaleFilename:      "CnnModels/wvrec-scale.txt"
     CnnPredCut:         0.5
+    UseSavedModelBundle: false
+
     tool_type: "WaveformRecogTf"
 }
 

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.h
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.h
@@ -1,7 +1,8 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //// Class:       Graph
 //// Authors:     R.Sulej (Robert.Sulej@cern.ch), from DUNE, FNAL/NCBJ, Sept. 2017
-///               P.Plonski,                      from DUNE, WUT, Sept. 2017
+////              P.Plonski,                      from DUNE, WUT, Sept. 2017
+////              T.Cai (tejinc@yorku.ca)         from DUNE, YorkU, March 2022
 ////
 //// Iterface to run Tensorflow graph saved to a file. First attempts, almost functional.
 ////
@@ -18,6 +19,9 @@ namespace tensorflow
 {
     class Session;
     class Tensor;
+    class SessionOptions;
+    class RunOptions;
+    class SavedModelBundle;
 }
 
 namespace tf
@@ -26,10 +30,10 @@ namespace tf
 class Graph
 {
 public:
-    static std::unique_ptr<Graph> create(const char* graph_file_name, const std::vector<std::string> & outputs = {})
+    static std::unique_ptr<Graph> create(const char* graph_file_name, const std::vector<std::string> & outputs = {}, bool use_bundle=false)
     {
         bool success;
-        std::unique_ptr<Graph> ptr(new Graph(graph_file_name, outputs,  success));
+        std::unique_ptr<Graph> ptr(new Graph(graph_file_name, outputs,  success, use_bundle));
         if (success) { return ptr; }
         else { return nullptr; }
     }
@@ -47,9 +51,13 @@ public:
 
 private:
     /// Not-throwing constructor.
-    Graph(const char* graph_file_name, const std::vector<std::string> & outputs, bool & success);
+    Graph(const char* graph_file_name, const std::vector<std::string> & outputs, bool & success, bool use_bundle = false);
 
     tensorflow::Session* fSession;
+    bool fUseBundle;
+    tensorflow::SessionOptions*   fSessionOptions;
+    tensorflow::RunOptions*   fRunOptions;
+    tensorflow::SavedModelBundle* fBundle;
     std::string fInputName;
     std::vector< std::string > fOutputNames;
 };


### PR DESCRIPTION
Two issues currently exist:
1. Needs to find input tensor name dynamically. With SavedModelBundle the input name cannot be found from graphdef as the format has been changed. People have been able to use the `saved_model_cli` to inspect the saved model folder to get the name. Afterward this name needs to prepend a prefix, i.e. `"serving_default_{inputname}"`.
2. I encountered this error:
    `F tensorflow/core/framework/tensor_shape.cc:36] Check failed: NDIMS == dims() (2 vs. 1) Asking for tensor of 2 dimensions from a tensor of 1 dimensions`
   while running the code. A google search suggests this might be a bug in tensorflow: see [issue 9282](https://github.com/tensorflow/tensorflow/issues/9282) in tensorflow github