### PR TITLE
Convert TDC to tick for true energy deposition.

### DIFF
--- a/larrecodnn/ImagePatternAlgs/Tensorflow/PointIdAlg/PointIdAlg.cxx
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/PointIdAlg/PointIdAlg.cxx
@@ -1016,7 +1016,7 @@ nnet::TrainingDataAlg::setEventData(const art::Event& event,
       
       int tick_idx = clockData.TPCTDC2Tick(ttc.first) + fAdcDelay;
 
-      if (tick_idx < labels_size && tick_idx > 0) {
+      if (tick_idx < labels_size && tick_idx >= 0) {
         labels_deposit[tick_idx] = max_deposit;
         labels_pdg[tick_idx] = max_pdg & type_pdg_mask;
       }

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/PointIdAlg/PointIdAlg.cxx
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/PointIdAlg/PointIdAlg.cxx
@@ -1013,13 +1013,12 @@ nnet::TrainingDataAlg::setEventData(const art::Event& event,
           max_pdg = trackToPDG[tc.first];
         }
       }
+      
+      int tick_idx = clockData.TPCTDC2Tick(ttc.first) + fAdcDelay;
 
-      if (ttc.first < labels_size) {
-        int tick_idx = ttc.first + fAdcDelay;
-        if (tick_idx < labels_size) {
-          labels_deposit[tick_idx] = max_deposit;
-          labels_pdg[tick_idx] = max_pdg & type_pdg_mask;
-        }
+      if (tick_idx < labels_size && tick_idx > 0) {
+        labels_deposit[tick_idx] = max_deposit;
+        labels_pdg[tick_idx] = max_pdg & type_pdg_mask;
       }
     }
 


### PR DESCRIPTION
While testing this code on SBND,  Mun Jung and I noticed a need to convert the tdc value in SimChannel to the electronics time tick in order to be comparable with the real readout. Now this conversion is properly done so this code should work for all detectors. Thank you to Dom Brailsford for pointing this problem out. 