### PR TITLE
Add a module and a tool to save images to hdf5 format for ML training.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,9 @@ find_package(TRITON QUIET EXPORT)
 find_package(TensorFlow 2.6.0 QUIET EXPORT)
 find_package(Threads REQUIRED EXPORT)
 
+find_package(hdf5 REQUIRED EXPORT) 
+find_package(hep_hpc REQUIRED EXPORT) 
+
 # macros for dictionary and simple_plugin
 include(ArtDictionary)
 include(CetMake)

--- a/larrecodnn/CMakeLists.txt
+++ b/larrecodnn/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(ImagePatternAlgs)
 add_subdirectory(CVN)
+add_subdirectory(ImageMaker)

--- a/larrecodnn/ImageMaker/CMakeLists.txt
+++ b/larrecodnn/ImageMaker/CMakeLists.txt
@@ -1,0 +1,38 @@
+art_make(BASENAME_ONLY
+  MODULE_LIBRARIES
+  art::Framework_Core
+  art::Framework_Principal
+  art::Framework_Services_Registry
+  art_root_io::tfile_support
+  ROOT::Core
+  art_root_io::TFileService_service
+  art::Persistency_Common
+  canvas::canvas
+  art::Persistency_Provenance
+  art::Utilities
+  messagefacility::MF_MessageLogger
+  cetlib 
+  cetlib_except
+  lardataobj::RecoBase
+  lardata::Utilities
+  larcorealg::Geometry
+  nusimdata::SimulationBase
+  larsim::MCCheater_PhotonBackTrackerService_service           
+  larsim::MCCheater_BackTrackerService_service           
+  larsim::MCCheater_ParticleInventoryService_service
+  larreco::RecoAlg
+  ROOT_BASIC_LIB_LIST
+  hep_hpc_hdf5
+  ${HDF5_LIBRARIES}
+  TOOL_LIBRARIES
+  art::Framework_Core
+  larcorealg::Geometry
+  ROOT_BASIC_LIB_LIST     
+  hep_hpc_hdf5
+  ${HDF5_LIBRARIES}
+
+  )
+
+install_headers()
+install_fhicl()
+install_source()

--- a/larrecodnn/ImageMaker/CMakeLists.txt
+++ b/larrecodnn/ImageMaker/CMakeLists.txt
@@ -1,37 +1,23 @@
-art_make(BASENAME_ONLY
-  MODULE_LIBRARIES
-  art::Framework_Core
-  art::Framework_Principal
-  art::Framework_Services_Registry
-  art_root_io::tfile_support
-  ROOT::Core
-  art_root_io::TFileService_service
-  art::Persistency_Common
-  canvas::canvas
-  art::Persistency_Provenance
-  art::Utilities
-  messagefacility::MF_MessageLogger
-  cetlib 
-  cetlib_except
-  lardataobj::RecoBase
-  lardata::Utilities
-  larcorealg::Geometry
-  nusimdata::SimulationBase
-  larsim::MCCheater_PhotonBackTrackerService_service           
-  larsim::MCCheater_BackTrackerService_service           
-  larsim::MCCheater_ParticleInventoryService_service
-  larreco::RecoAlg
-  ROOT_BASIC_LIB_LIST
-  hep_hpc_hdf5
-  ${HDF5_LIBRARIES}
-  TOOL_LIBRARIES
-  art::Framework_Core
-  larcorealg::Geometry
-  ROOT_BASIC_LIB_LIST     
-  hep_hpc_hdf5
-  ${HDF5_LIBRARIES}
 
-  )
+include_directories($ENV{HEP_HPC_INC})
+include_directories($ENV{HDF5_INC})
+cet_build_plugin(SaveImageH5 art::EDAnalyzer
+  LIBRARIES PRIVATE
+  hep_hpc_hdf5
+  hdf5_libraries
+)
+
+cet_build_plugin(SavePiMu art::tool
+  LIBRARIES PRIVATE
+  art::Framework_Core
+  larcore::Geometry_Geometry_service
+  larcorealg::Geometry
+  lardataobj::RecoBase
+  nusimdata::SimulationBase
+  hep_hpc_hdf5
+  hdf5_libraries
+)
+
 
 install_headers()
 install_fhicl()

--- a/larrecodnn/ImageMaker/ImageMaker.h
+++ b/larrecodnn/ImageMaker/ImageMaker.h
@@ -1,0 +1,8 @@
+#include "art/Framework/Principal/Event.h" 
+#include "hep_hpc/hdf5/File.hpp"
+
+namespace dnn{
+
+  void saveImage(art::Event const&, hep_hpc::hdf5::File &);
+
+}

--- a/larrecodnn/ImageMaker/ImageMaker.h
+++ b/larrecodnn/ImageMaker/ImageMaker.h
@@ -1,8 +1,8 @@
-#include "art/Framework/Principal/Event.h" 
+#include "art/Framework/Principal/Event.h"
 #include "hep_hpc/hdf5/File.hpp"
 
-namespace dnn{
+namespace dnn {
 
-  void saveImage(art::Event const&, hep_hpc::hdf5::File &);
+  void saveImage(art::Event const&, hep_hpc::hdf5::File&);
 
 }

--- a/larrecodnn/ImageMaker/SaveImageH5_module.cc
+++ b/larrecodnn/ImageMaker/SaveImageH5_module.cc
@@ -13,7 +13,7 @@
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/SubRun.h"
-#include "art/Utilities/make_tool.h" 
+#include "art/Utilities/make_tool.h"
 #include "canvas/Utilities/InputTag.h"
 #include "fhiclcpp/ParameterSet.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
@@ -23,7 +23,6 @@
 namespace dnn {
   class SaveImageH5;
 }
-
 
 class dnn::SaveImageH5 : public art::EDAnalyzer {
 public:
@@ -45,26 +44,23 @@ public:
   void beginJob() override;
 
 private:
-
   // Declare member data here.
   hep_hpc::hdf5::File hdffile;
-  std::function <decltype(dnn::saveImage)> saveImage_; 
+  std::function<decltype(dnn::saveImage)> saveImage_;
   std::string fHDF5FileName;
 };
 
-
 dnn::SaveImageH5::SaveImageH5(fhicl::ParameterSet const& p)
-  : EDAnalyzer{p},
-  saveImage_{art::make_tool<decltype(dnn::saveImage)>(p.get<fhicl::ParameterSet>("imageMaker"), "saveImage")},
-  fHDF5FileName(p.get<std::string>("HDF5NAME"))
-  // More initializers here.
+  : EDAnalyzer{p}
+  , saveImage_{art::make_tool<decltype(dnn::saveImage)>(p.get<fhicl::ParameterSet>("imageMaker"),
+                                                        "saveImage")}
+  , fHDF5FileName(p.get<std::string>("HDF5NAME"))
+// More initializers here.
 {
   // Call appropriate consumes<>() for any products to be retrieved by this module.
 }
 
-dnn::SaveImageH5::~SaveImageH5() noexcept
-{
-}
+dnn::SaveImageH5::~SaveImageH5() noexcept {}
 
 void dnn::SaveImageH5::analyze(art::Event const& e)
 {

--- a/larrecodnn/ImageMaker/SaveImageH5_module.cc
+++ b/larrecodnn/ImageMaker/SaveImageH5_module.cc
@@ -39,7 +39,6 @@ public:
   void beginJob() override;
 
 private:
-
   hep_hpc::hdf5::File hdffile;
   std::function<decltype(dnn::saveImage)> saveImage_;
   std::string fHDF5FileName;
@@ -50,8 +49,7 @@ dnn::SaveImageH5::SaveImageH5(fhicl::ParameterSet const& p)
   , saveImage_{art::make_tool<decltype(dnn::saveImage)>(p.get<fhicl::ParameterSet>("imageMaker"),
                                                         "saveImage")}
   , fHDF5FileName(p.get<std::string>("HDF5NAME"))
-{
-}
+{}
 
 dnn::SaveImageH5::~SaveImageH5() noexcept {}
 

--- a/larrecodnn/ImageMaker/SaveImageH5_module.cc
+++ b/larrecodnn/ImageMaker/SaveImageH5_module.cc
@@ -27,24 +27,19 @@ namespace dnn {
 class dnn::SaveImageH5 : public art::EDAnalyzer {
 public:
   explicit SaveImageH5(fhicl::ParameterSet const& p);
-  // The compiler-generated destructor is fine for non-base
-  // classes without bare pointers or other resource use.
 
-  // Plugins should not be copied or assigned.
   SaveImageH5(SaveImageH5 const&) = delete;
   SaveImageH5(SaveImageH5&&) = delete;
   SaveImageH5& operator=(SaveImageH5 const&) = delete;
   SaveImageH5& operator=(SaveImageH5&&) = delete;
 
-  // Required functions.
   void analyze(art::Event const& e) override;
   virtual ~SaveImageH5() noexcept;
 
-  // Selected optional functions.
   void beginJob() override;
 
 private:
-  // Declare member data here.
+
   hep_hpc::hdf5::File hdffile;
   std::function<decltype(dnn::saveImage)> saveImage_;
   std::string fHDF5FileName;
@@ -55,22 +50,18 @@ dnn::SaveImageH5::SaveImageH5(fhicl::ParameterSet const& p)
   , saveImage_{art::make_tool<decltype(dnn::saveImage)>(p.get<fhicl::ParameterSet>("imageMaker"),
                                                         "saveImage")}
   , fHDF5FileName(p.get<std::string>("HDF5NAME"))
-// More initializers here.
 {
-  // Call appropriate consumes<>() for any products to be retrieved by this module.
 }
 
 dnn::SaveImageH5::~SaveImageH5() noexcept {}
 
 void dnn::SaveImageH5::analyze(art::Event const& e)
 {
-  // Implementation of required member function here.
   saveImage_(e, hdffile);
 }
 
 void dnn::SaveImageH5::beginJob()
 {
-  // Implementation of optional member function here.
   hdffile = hep_hpc::hdf5::File(fHDF5FileName, H5F_ACC_TRUNC);
 }
 

--- a/larrecodnn/ImageMaker/SaveImageH5_module.cc
+++ b/larrecodnn/ImageMaker/SaveImageH5_module.cc
@@ -1,0 +1,81 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       SaveImageH5
+// Plugin Type: analyzer (Unknown Unknown)
+// File:        SaveImageH5_module.cc
+//
+// Generated at Thu Feb  9 17:15:36 2023 by Tingjun Yang using cetskelgen
+// from  version .
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "art/Utilities/make_tool.h" 
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "ImageMaker.h"
+
+namespace dnn {
+  class SaveImageH5;
+}
+
+
+class dnn::SaveImageH5 : public art::EDAnalyzer {
+public:
+  explicit SaveImageH5(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  SaveImageH5(SaveImageH5 const&) = delete;
+  SaveImageH5(SaveImageH5&&) = delete;
+  SaveImageH5& operator=(SaveImageH5 const&) = delete;
+  SaveImageH5& operator=(SaveImageH5&&) = delete;
+
+  // Required functions.
+  void analyze(art::Event const& e) override;
+  virtual ~SaveImageH5() noexcept;
+
+  // Selected optional functions.
+  void beginJob() override;
+
+private:
+
+  // Declare member data here.
+  hep_hpc::hdf5::File hdffile;
+  std::function <decltype(dnn::saveImage)> saveImage_; 
+  std::string fHDF5FileName;
+};
+
+
+dnn::SaveImageH5::SaveImageH5(fhicl::ParameterSet const& p)
+  : EDAnalyzer{p},
+  saveImage_{art::make_tool<decltype(dnn::saveImage)>(p.get<fhicl::ParameterSet>("imageMaker"), "saveImage")},
+  fHDF5FileName(p.get<std::string>("HDF5NAME"))
+  // More initializers here.
+{
+  // Call appropriate consumes<>() for any products to be retrieved by this module.
+}
+
+dnn::SaveImageH5::~SaveImageH5() noexcept
+{
+}
+
+void dnn::SaveImageH5::analyze(art::Event const& e)
+{
+  // Implementation of required member function here.
+  saveImage_(e, hdffile);
+}
+
+void dnn::SaveImageH5::beginJob()
+{
+  // Implementation of optional member function here.
+  hdffile = hep_hpc::hdf5::File(fHDF5FileName, H5F_ACC_TRUNC);
+}
+
+DEFINE_ART_MODULE(dnn::SaveImageH5)

--- a/larrecodnn/ImageMaker/SavePiMu_tool.cc
+++ b/larrecodnn/ImageMaker/SavePiMu_tool.cc
@@ -100,7 +100,7 @@ namespace dnn {
             //std::cout<<vhit[ihit]->WireID().toString()<<std::endl;
             auto endwire = vhit[ihit]->WireID();
             float endtime = vhit[ihit]->PeakTime();
-            float adc[50][50] = {0.};
+            float adc[50][50] = {{0.}};
             for (auto& wire : wires) {
               int channel = wire->Channel();
               auto wireids = geom->ChannelToWire(channel);

--- a/larrecodnn/ImageMaker/SavePiMu_tool.cc
+++ b/larrecodnn/ImageMaker/SavePiMu_tool.cc
@@ -66,7 +66,6 @@ namespace dnn {
     unsigned short flag = 999;
     if (!mclist.empty()) {
       auto particle = mclist[0].GetParticle(0);
-      //std::cout<<"pdg = "<<particle.PdgCode()<<std::endl;
       if (std::abs(particle.PdgCode()) == 13) flag = 0;
       if (std::abs(particle.PdgCode()) == 211) flag = 1;
     }
@@ -75,7 +74,6 @@ namespace dnn {
       auto trkend = tracks[0].End();
       if (trkend.X() > -360 + 50 && trkend.X() < 360 - 50 && trkend.Y() > 50 &&
           trkend.Y() < 610 - 50 && trkend.Z() > 50 && trkend.Z() < 710 - 50) {
-        //std::cout<<trkend.X()<<" "<<trkend.Y()<<" "<<trkend.Z()<<std::endl;
         if (fmthm.isValid()) {
           auto vhit = fmthm.at(0);
           auto vmeta = fmthm.data(0);
@@ -83,7 +81,6 @@ namespace dnn {
           int maxindex = -1;
           for (size_t i = 0; i < vhit.size(); ++i) {
             if (vmeta[i]->Index() == std::numeric_limits<int>::max()) { continue; }
-            //std::cout<<i<<" "<<vmeta[i]->Index()<<std::endl;
             if (vhit[i]->WireID().Plane == 2) {
               if (int(vmeta[i]->Index()) > maxindex) {
                 maxindex = vmeta[i]->Index();
@@ -92,18 +89,15 @@ namespace dnn {
             }
           }
           if (ihit >= 0) {
-            //std::cout<<vhit[ihit]->WireID().toString()<<std::endl;
             auto endwire = vhit[ihit]->WireID();
             float endtime = vhit[ihit]->PeakTime();
             float adc[50][50] = {{0.}};
             for (auto& wire : wires) {
               int channel = wire.Channel();
               auto wireids = geom->ChannelToWire(channel);
-              //std::cout<<wireids[0].toString()<<std::endl;
               if (wireids[0].Plane == 2 && wireids[0].TPC == endwire.TPC &&
                   wireids[0].Wire >= endwire.Wire - 25 && wireids[0].Wire < endwire.Wire + 25) {
                 int idx = wireids[0].Wire - endwire.Wire + 25;
-                //std::cout<<"idx = "<<idx<<std::endl;
                 const recob::Wire::RegionsOfInterest_t& signalROI = wire.SignalROI();
                 int lasttick = 0;
                 for (const auto& range : signalROI.get_ranges()) {
@@ -119,7 +113,6 @@ namespace dnn {
                   for (size_t i = 0; i < waveform.size(); ++i) {
                     if (lasttick >= int(endtime) - 25 && lasttick < int(endtime) + 25) {
                       adc[idx][lasttick - int(endtime) + 25] = waveform[i];
-                      //std::cout<<idx<<" "<<lasttick-int(endtime)-25<<" "<<waveform[i]<<std::endl;
                       ++lasttick;
                     }
                   }

--- a/larrecodnn/ImageMaker/SavePiMu_tool.cc
+++ b/larrecodnn/ImageMaker/SavePiMu_tool.cc
@@ -1,92 +1,85 @@
-#include "art/Utilities/ToolMacros.h" 
+#include "art/Framework/Core/ModuleMacros.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/SubRun.h"
-#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Utilities/ToolMacros.h"
 #include "canvas/Persistency/Common/FindManyP.h"
 
+#include "larcore/Geometry/Geometry.h"
+#include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Track.h"
 #include "lardataobj/RecoBase/TrackHitMeta.h"
-#include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Wire.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
-#include "larcore/Geometry/Geometry.h"
 
-#include "ImageMaker.h" 
+#include "ImageMaker.h"
+#include "TTimeStamp.h"
 #include "hep_hpc/hdf5/Ntuple.hpp"
 #include "hep_hpc/hdf5/make_ntuple.hpp"
-#include "TTimeStamp.h"
 
 using namespace hep_hpc::hdf5;
 
-namespace dnn{
+namespace dnn {
 
-  void saveImage(art::Event const& e, hep_hpc::hdf5::File &hdffile){
+  void saveImage(art::Event const& e, hep_hpc::hdf5::File& hdffile)
+  {
 
     art::ServiceHandle<geo::Geometry> geom;
 
-    static Ntuple<unsigned int, unsigned int, unsigned int, double> evtids(hdffile, "evtids", {"run", "subrun", "event", "evttime"});
+    static Ntuple<unsigned int, unsigned int, unsigned int, double> evtids(
+      hdffile, "evtids", {"run", "subrun", "event", "evttime"});
 
-    static auto image = make_ntuple(
-      {hdffile, "image", 1000},
-      make_scalar_column<unsigned short>("label"),
-      make_column<float, 2>("adc", // 2 means each element is a 2-d array
-                          {50, 50}, // extent of each array dimension
-                          1024 * 1024 / (2500 * sizeof(float)), // chunk size
-                          {PropertyList{H5P_DATASET_CREATE}(&H5Pset_shuffle)(&H5Pset_deflate,6u)}));
+    static auto image =
+      make_ntuple({hdffile, "image", 1000},
+                  make_scalar_column<unsigned short>("label"),
+                  make_column<float, 2>(
+                    "adc",                                // 2 means each element is a 2-d array
+                    {50, 50},                             // extent of each array dimension
+                    1024 * 1024 / (2500 * sizeof(float)), // chunk size
+                    {PropertyList{H5P_DATASET_CREATE}(&H5Pset_shuffle)(&H5Pset_deflate, 6u)}));
 
     // Get event information
     double evttime;
 
     art::Timestamp ts = e.time();
-    if (ts.timeHigh() == 0){
+    if (ts.timeHigh() == 0) {
       TTimeStamp tts(ts.timeLow());
       evttime = tts.AsDouble();
     }
-    else{
+    else {
       TTimeStamp tts(ts.timeHigh(), ts.timeLow());
       evttime = tts.AsDouble();
     }
 
     // Get image information
     // * tracks
-    std::vector<art::Ptr<recob::Track> > tracklist;
-    auto trackListHandle = e.getHandle< std::vector<recob::Track> >("pandoraTrack");
-    if (trackListHandle)
-      art::fill_ptr_vector(tracklist, trackListHandle);
+    std::vector<art::Ptr<recob::Track>> tracklist;
+    auto trackListHandle = e.getHandle<std::vector<recob::Track>>("pandoraTrack");
+    if (trackListHandle) art::fill_ptr_vector(tracklist, trackListHandle);
 
-    art::FindManyP<recob::Hit, recob::TrackHitMeta> fmthm(
-      trackListHandle,
-      e, "pandoraTrack");
+    art::FindManyP<recob::Hit, recob::TrackHitMeta> fmthm(trackListHandle, e, "pandoraTrack");
 
-    std::vector < art::Ptr < recob::Wire > > wires;
-    auto wireListHandle = e.getHandle < std::vector < recob::Wire > >("wclsdatasp:gauss");
-    if (wireListHandle) {
-      art::fill_ptr_vector(wires, wireListHandle);
-    }
+    std::vector<art::Ptr<recob::Wire>> wires;
+    auto wireListHandle = e.getHandle<std::vector<recob::Wire>>("wclsdatasp:gauss");
+    if (wireListHandle) { art::fill_ptr_vector(wires, wireListHandle); }
 
     // * MC truth information
-    std::vector<art::Ptr<simb::MCTruth> > mclist;
-    auto mctruthListHandle = e.getHandle< std::vector<simb::MCTruth> >("generator");
-    if (mctruthListHandle)
-      art::fill_ptr_vector(mclist, mctruthListHandle);
+    std::vector<art::Ptr<simb::MCTruth>> mclist;
+    auto mctruthListHandle = e.getHandle<std::vector<simb::MCTruth>>("generator");
+    if (mctruthListHandle) art::fill_ptr_vector(mclist, mctruthListHandle);
 
     unsigned short flag = 999;
-    if (!mclist.empty()){
+    if (!mclist.empty()) {
       auto particle = mclist[0]->GetParticle(0);
       //std::cout<<"pdg = "<<particle.PdgCode()<<std::endl;
       if (std::abs(particle.PdgCode()) == 13) flag = 0;
       if (std::abs(particle.PdgCode()) == 211) flag = 1;
     }
 
-    if (!tracklist.empty()){
+    if (!tracklist.empty()) {
       auto trkend = tracklist[0]->End();
-      if (trkend.X() > -360+50 &&
-          trkend.X() < 360-50 &&
-          trkend.Y() > 50 &&
-          trkend.Y() < 610-50 &&
-          trkend.Z() > 50 &&
-          trkend.Z() < 710-50){
+      if (trkend.X() > -360 + 50 && trkend.X() < 360 - 50 && trkend.Y() > 50 &&
+          trkend.Y() < 610 - 50 && trkend.Z() > 50 && trkend.Z() < 710 - 50) {
         //std::cout<<trkend.X()<<" "<<trkend.Y()<<" "<<trkend.Z()<<std::endl;
         if (fmthm.isValid()) {
           auto vhit = fmthm.at(0);
@@ -94,62 +87,55 @@ namespace dnn{
           int ihit = -1;
           int maxindex = -1;
           for (size_t i = 0; i < vhit.size(); ++i) {
-            if (vmeta[i]->Index() == std::numeric_limits<int>::max()) {
-              continue;
-            }
+            if (vmeta[i]->Index() == std::numeric_limits<int>::max()) { continue; }
             //std::cout<<i<<" "<<vmeta[i]->Index()<<std::endl;
-            if (vhit[i]->WireID().Plane == 2){
-              if (int(vmeta[i]->Index())>maxindex){
+            if (vhit[i]->WireID().Plane == 2) {
+              if (int(vmeta[i]->Index()) > maxindex) {
                 maxindex = vmeta[i]->Index();
                 ihit = i;
               }
             }
           }
-          if (ihit>=0){
+          if (ihit >= 0) {
             //std::cout<<vhit[ihit]->WireID().toString()<<std::endl;
             auto endwire = vhit[ihit]->WireID();
             float endtime = vhit[ihit]->PeakTime();
             float adc[50][50] = {0.};
-            for (auto & wire : wires){
+            for (auto& wire : wires) {
               int channel = wire->Channel();
               auto wireids = geom->ChannelToWire(channel);
               //std::cout<<wireids[0].toString()<<std::endl;
-              if (wireids[0].Plane==2 && 
-                  wireids[0].TPC == endwire.TPC &&
-                  wireids[0].Wire >= endwire.Wire - 25 &&
-                  wireids[0].Wire < endwire.Wire + 25){
-                int idx = wireids[0].Wire -endwire.Wire + 25;
+              if (wireids[0].Plane == 2 && wireids[0].TPC == endwire.TPC &&
+                  wireids[0].Wire >= endwire.Wire - 25 && wireids[0].Wire < endwire.Wire + 25) {
+                int idx = wireids[0].Wire - endwire.Wire + 25;
                 //std::cout<<"idx = "<<idx<<std::endl;
                 const recob::Wire::RegionsOfInterest_t& signalROI = wire->SignalROI();
                 int lasttick = 0;
-                for(const auto& range : signalROI.get_ranges()){
+                for (const auto& range : signalROI.get_ranges()) {
                   const auto& waveform = range.data();
                   // ROI start time
                   raw::TDCtick_t roiFirstBinTick = range.begin_index();
-                  for (int i = lasttick; i<roiFirstBinTick; ++i){
-                    if (i >= int(endtime) - 25 &&
-                        i <  int(endtime) + 25){
-                      adc[idx][i-int(endtime)-25] = 0;
+                  for (int i = lasttick; i < roiFirstBinTick; ++i) {
+                    if (i >= int(endtime) - 25 && i < int(endtime) + 25) {
+                      adc[idx][i - int(endtime) - 25] = 0;
                     }
                   }
                   lasttick = roiFirstBinTick;
-                  for(size_t i = 0; i < waveform.size(); ++i){
-                    if (lasttick >= int(endtime) - 25 &&
-                        lasttick <  int(endtime) + 25){
-                      adc[idx][lasttick-int(endtime)+25] = waveform[i];
+                  for (size_t i = 0; i < waveform.size(); ++i) {
+                    if (lasttick >= int(endtime) - 25 && lasttick < int(endtime) + 25) {
+                      adc[idx][lasttick - int(endtime) + 25] = waveform[i];
                       //std::cout<<idx<<" "<<lasttick-int(endtime)-25<<" "<<waveform[i]<<std::endl;
                       ++lasttick;
                     }
                   }
                 }
-                for (int i = lasttick; i<6000; ++i){
-                  if (i >= int(endtime) - 25 &&
-                      i <  int(endtime) + 25){
-                    adc[idx][i-int(endtime)+25] = 0;
+                for (int i = lasttick; i < 6000; ++i) {
+                  if (i >= int(endtime) - 25 && i < int(endtime) + 25) {
+                    adc[idx][i - int(endtime) + 25] = 0;
                   }
                 }
               }
-            }// Loop over all wire signals
+            } // Loop over all wire signals
             evtids.insert(e.run(), e.subRun(), e.id().event(), evttime);
             image.insert(flag, &adc[0][0]);
           }

--- a/larrecodnn/ImageMaker/SavePiMu_tool.cc
+++ b/larrecodnn/ImageMaker/SavePiMu_tool.cc
@@ -1,0 +1,164 @@
+#include "art/Utilities/ToolMacros.h" 
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "canvas/Persistency/Common/FindManyP.h"
+
+#include "lardataobj/RecoBase/Track.h"
+#include "lardataobj/RecoBase/TrackHitMeta.h"
+#include "lardataobj/RecoBase/Hit.h"
+#include "lardataobj/RecoBase/Wire.h"
+#include "nusimdata/SimulationBase/MCTruth.h"
+#include "larcore/Geometry/Geometry.h"
+
+#include "ImageMaker.h" 
+#include "hep_hpc/hdf5/Ntuple.hpp"
+#include "hep_hpc/hdf5/make_ntuple.hpp"
+#include "TTimeStamp.h"
+
+using namespace hep_hpc::hdf5;
+
+namespace dnn{
+
+  void saveImage(art::Event const& e, hep_hpc::hdf5::File &hdffile){
+
+    art::ServiceHandle<geo::Geometry> geom;
+
+    static Ntuple<unsigned int, unsigned int, unsigned int, double> evtids(hdffile, "evtids", {"run", "subrun", "event", "evttime"});
+
+    static auto image = make_ntuple(
+      {hdffile, "image", 1000},
+      make_scalar_column<unsigned short>("label"),
+      make_column<float, 2>("adc", // 2 means each element is a 2-d array
+                          {50, 50}, // extent of each array dimension
+                          1024 * 1024 / (2500 * sizeof(float)), // chunk size
+                          {PropertyList{H5P_DATASET_CREATE}(&H5Pset_shuffle)(&H5Pset_deflate,6u)}));
+
+    // Get event information
+    double evttime;
+
+    art::Timestamp ts = e.time();
+    if (ts.timeHigh() == 0){
+      TTimeStamp tts(ts.timeLow());
+      evttime = tts.AsDouble();
+    }
+    else{
+      TTimeStamp tts(ts.timeHigh(), ts.timeLow());
+      evttime = tts.AsDouble();
+    }
+
+    // Get image information
+    // * tracks
+    std::vector<art::Ptr<recob::Track> > tracklist;
+    auto trackListHandle = e.getHandle< std::vector<recob::Track> >("pandoraTrack");
+    if (trackListHandle)
+      art::fill_ptr_vector(tracklist, trackListHandle);
+
+    art::FindManyP<recob::Hit, recob::TrackHitMeta> fmthm(
+      trackListHandle,
+      e, "pandoraTrack");
+
+    std::vector < art::Ptr < recob::Wire > > wires;
+    auto wireListHandle = e.getHandle < std::vector < recob::Wire > >("wclsdatasp:gauss");
+    if (wireListHandle) {
+      art::fill_ptr_vector(wires, wireListHandle);
+    }
+
+    // * MC truth information
+    std::vector<art::Ptr<simb::MCTruth> > mclist;
+    auto mctruthListHandle = e.getHandle< std::vector<simb::MCTruth> >("generator");
+    if (mctruthListHandle)
+      art::fill_ptr_vector(mclist, mctruthListHandle);
+
+    unsigned short flag = 999;
+    if (!mclist.empty()){
+      auto particle = mclist[0]->GetParticle(0);
+      //std::cout<<"pdg = "<<particle.PdgCode()<<std::endl;
+      if (std::abs(particle.PdgCode()) == 13) flag = 0;
+      if (std::abs(particle.PdgCode()) == 211) flag = 1;
+    }
+
+    if (!tracklist.empty()){
+      auto trkend = tracklist[0]->End();
+      if (trkend.X() > -360+50 &&
+          trkend.X() < 360-50 &&
+          trkend.Y() > 50 &&
+          trkend.Y() < 610-50 &&
+          trkend.Z() > 50 &&
+          trkend.Z() < 710-50){
+        //std::cout<<trkend.X()<<" "<<trkend.Y()<<" "<<trkend.Z()<<std::endl;
+        if (fmthm.isValid()) {
+          auto vhit = fmthm.at(0);
+          auto vmeta = fmthm.data(0);
+          int ihit = -1;
+          int maxindex = -1;
+          for (size_t i = 0; i < vhit.size(); ++i) {
+            if (vmeta[i]->Index() == std::numeric_limits<int>::max()) {
+              continue;
+            }
+            //std::cout<<i<<" "<<vmeta[i]->Index()<<std::endl;
+            if (vhit[i]->WireID().Plane == 2){
+              if (int(vmeta[i]->Index())>maxindex){
+                maxindex = vmeta[i]->Index();
+                ihit = i;
+              }
+            }
+          }
+          if (ihit>=0){
+            //std::cout<<vhit[ihit]->WireID().toString()<<std::endl;
+            auto endwire = vhit[ihit]->WireID();
+            float endtime = vhit[ihit]->PeakTime();
+            float adc[50][50] = {0.};
+            for (auto & wire : wires){
+              int channel = wire->Channel();
+              auto wireids = geom->ChannelToWire(channel);
+              //std::cout<<wireids[0].toString()<<std::endl;
+              if (wireids[0].Plane==2 && 
+                  wireids[0].TPC == endwire.TPC &&
+                  wireids[0].Wire >= endwire.Wire - 25 &&
+                  wireids[0].Wire < endwire.Wire + 25){
+                int idx = wireids[0].Wire -endwire.Wire + 25;
+                //std::cout<<"idx = "<<idx<<std::endl;
+                const recob::Wire::RegionsOfInterest_t& signalROI = wire->SignalROI();
+                int lasttick = 0;
+                for(const auto& range : signalROI.get_ranges()){
+                  const auto& waveform = range.data();
+                  // ROI start time
+                  raw::TDCtick_t roiFirstBinTick = range.begin_index();
+                  for (int i = lasttick; i<roiFirstBinTick; ++i){
+                    if (i >= int(endtime) - 25 &&
+                        i <  int(endtime) + 25){
+                      adc[idx][i-int(endtime)-25] = 0;
+                    }
+                  }
+                  lasttick = roiFirstBinTick;
+                  for(size_t i = 0; i < waveform.size(); ++i){
+                    if (lasttick >= int(endtime) - 25 &&
+                        lasttick <  int(endtime) + 25){
+                      adc[idx][lasttick-int(endtime)+25] = waveform[i];
+                      //std::cout<<idx<<" "<<lasttick-int(endtime)-25<<" "<<waveform[i]<<std::endl;
+                      ++lasttick;
+                    }
+                  }
+                }
+                for (int i = lasttick; i<6000; ++i){
+                  if (i >= int(endtime) - 25 &&
+                      i <  int(endtime) + 25){
+                    adc[idx][i-int(endtime)+25] = 0;
+                  }
+                }
+              }
+            }// Loop over all wire signals
+            evtids.insert(e.run(), e.subRun(), e.id().event(), evttime);
+            image.insert(flag, &adc[0][0]);
+          }
+        }
+      }
+    }
+
+    return;
+  }
+}
+
+DEFINE_ART_FUNCTION_TOOL(dnn::saveImage, "saveImage")

--- a/larrecodnn/ImageMaker/makepimuh5.fcl
+++ b/larrecodnn/ImageMaker/makepimuh5.fcl
@@ -4,63 +4,26 @@ process_name: HDF5Ana
 
 services:
 {
-  # Load the service that manages root files for histograms.
-  #TFileService: { fileName: "ana_hist.root" }
   MemoryTracker:     {}
   TimeTracker:       {}
-  #RandomNumberGenerator: {}
-  #FileCatalogMetadata:  @local::art_file_catalog_mc
   @table::protodune_services
 }
-#services.PhotonVisibilityService:      @local::protodune_photonvisibilityservice
-#source is now a root file
+
 source:
 {
   module_type: RootInput
   maxEvents:  10        # Number of events to create
 }
 
-# Define and configure some modules to do work on each event.
-# First modules are defined; they are scheduled later.
-# Modules are grouped by type.
 physics:
 {
  analyzers:
 {
- #analysistree:      @local::protodune_analysistree
- #disambigcheck:     @local::standard_disambigcheck
-
 }
- #define the output stream, there could be more than one if using filters 
-# stream1:  [ out1 ]
-
- #define the producer and filter modules for this path, order matters, 
- #filters reject all following items.  see lines starting physics.producers below
-# ana:  [ disambigcheck, analysistree ]
  ana:  [ pimuh5 ]
 
- #end_paths is a keyword and contains the paths that do not modify the art::Event, 
- #ie analyzers and output streams.  these all run simultaneously
-# end_paths:     [stream1,ana]  
-# end_paths:     [stream1]  
  end_paths:     [ana]
 }
-
-#block to define where the output goes.  if you defined a filter in the physics
-#block and put it in the trigger_paths then you need to put a SelectEvents: {SelectEvents: [XXX]}
-#entry in the output stream you want those to go to, where XXX is the label of the filter module(s)
-#outputs:
-#{
-# out1:
-# {
-#   module_type: RootOutput
-#   fileName:    "%ifb_%tc_merged.root"
-#   dataTier:    "full-reconstructed"
-#   compressionLevel: 1
-# }
-#}
-
-### Here, we overwrite ALL module Labels with the ones defined above.
 
 physics.analyzers.pimuh5: {
     module_type: "SaveImageH5"

--- a/larrecodnn/ImageMaker/makepimuh5.fcl
+++ b/larrecodnn/ImageMaker/makepimuh5.fcl
@@ -1,0 +1,73 @@
+#include "services_dune.fcl"
+
+process_name: HDF5Ana
+
+services:
+{
+  # Load the service that manages root files for histograms.
+  #TFileService: { fileName: "ana_hist.root" }
+  MemoryTracker:     {}
+  TimeTracker:       {}
+  #RandomNumberGenerator: {}
+  #FileCatalogMetadata:  @local::art_file_catalog_mc
+  @table::protodune_services
+}
+#services.PhotonVisibilityService:      @local::protodune_photonvisibilityservice
+#source is now a root file
+source:
+{
+  module_type: RootInput
+  maxEvents:  10        # Number of events to create
+}
+
+# Define and configure some modules to do work on each event.
+# First modules are defined; they are scheduled later.
+# Modules are grouped by type.
+physics:
+{
+ analyzers:
+{
+ #analysistree:      @local::protodune_analysistree
+ #disambigcheck:     @local::standard_disambigcheck
+
+}
+ #define the output stream, there could be more than one if using filters 
+# stream1:  [ out1 ]
+
+ #define the producer and filter modules for this path, order matters, 
+ #filters reject all following items.  see lines starting physics.producers below
+# ana:  [ disambigcheck, analysistree ]
+ ana:  [ pimuh5 ]
+
+ #end_paths is a keyword and contains the paths that do not modify the art::Event, 
+ #ie analyzers and output streams.  these all run simultaneously
+# end_paths:     [stream1,ana]  
+# end_paths:     [stream1]  
+ end_paths:     [ana]
+}
+
+#block to define where the output goes.  if you defined a filter in the physics
+#block and put it in the trigger_paths then you need to put a SelectEvents: {SelectEvents: [XXX]}
+#entry in the output stream you want those to go to, where XXX is the label of the filter module(s)
+#outputs:
+#{
+# out1:
+# {
+#   module_type: RootOutput
+#   fileName:    "%ifb_%tc_merged.root"
+#   dataTier:    "full-reconstructed"
+#   compressionLevel: 1
+# }
+#}
+
+### Here, we overwrite ALL module Labels with the ones defined above.
+
+physics.analyzers.pimuh5: {
+    module_type: "SaveImageH5"
+    HDF5NAME: "test.h5"
+    imageMaker:{
+        tool_type: SavePiMu
+    }
+}
+
+services.BackTrackerService.BackTracker.SimChannelModuleLabel: "tpcrawdecoder:simpleSC"

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -253,6 +253,7 @@ larfinder       v09_00_01       -
 cetmodules	v3_20_00	-	only_for_build
 tensorflow	v2_6_0		-	optional
 triton		v2_3_0d		-	optional
+hep_hpc          v0_14_01        -
 end_product_list
 ####################################
 
@@ -307,13 +308,13 @@ end_product_list
 #   case it is optional.
 #
 ####################################
-qualifier	larreco		tensorflow	triton	larfinder
-c7:debug	c7:debug	c7:p392		c7      -nq-
-c7:prof 	c7:prof		c7:p392		c7      -nq-
-e19:debug	e19:debug	e19:p392	e19     -nq-
-e19:prof	e19:prof	e19:p392	e19     -nq-
-e20:debug	e20:debug	e20:p392	e20     -nq-
-e20:prof	e20:prof	e20:p392	e20     -nq-
+qualifier	larreco		tensorflow	triton	larfinder  hep_hpc
+c7:debug	c7:debug	c7:p392		c7      -nq-       c7:debug
+c7:prof 	c7:prof		c7:p392		c7      -nq-       c7:prof
+e19:debug	e19:debug	e19:p392	e19     -nq-       e19:prof
+e19:prof	e19:prof	e19:p392	e19     -nq-       e19:debug
+e20:debug	e20:debug	e20:p392	e20     -nq-       e20:debug
+e20:prof	e20:prof	e20:p392	e20     -nq-       e20:prof
 end_qualifier_list
 ####################################
 


### PR DESCRIPTION
This PR includes an analyzer module and a tool to save event images to hdf5 format for machine learning training. The tool is an example to save muon and pion images around the reconstructed track end. It should be easy to write different tools following that example to save different images. This PR means to provide a flexible framework to help people build different models. I plan to give a talk on this at a future larsoft coordination meeting. 

Right now this PR (ImageMaker) does not build. I would like to request help from LArSoft experts to modify the CMakeLists.txt file to make it compile (or provide instructions). Thank you. 