### PR TITLE
fix NuGraph vertex inference

### DIFF
--- a/larrecodnn/NuGraph/NuGraphInference_module.cc
+++ b/larrecodnn/NuGraph/NuGraphInference_module.cc
@@ -396,7 +396,7 @@ void NuGraphInference::produce(art::Event& e)
     }
   }
   if (vertexDecoder) {
-    torch::Tensor v = outputs.at("x_vertex").toGenericDict().at(0).toTensor();
+    torch::Tensor v = outputs.at("x_vtx").toGenericDict().at("evt").toTensor()[0];
     double vpos[3];
     vpos[0] = v[0].item<float>();
     vpos[1] = v[1].item<float>();

--- a/larrecodnn/NuGraph/NuSliceHitsProducer_module.cc
+++ b/larrecodnn/NuGraph/NuSliceHitsProducer_module.cc
@@ -62,7 +62,7 @@ NuSliceHitsProducer::NuSliceHitsProducer(fhicl::ParameterSet const& p)
   , fPfpLabel(p.get<std::string>("PfpLabel", "pandora"))
   , fSliceLabel(p.get<std::string>("SliceLabel", "pandora"))
   , fHitLabel(p.get<std::string>("HitLabel", "gaushit"))
-  , fHitTruthLabel(p.get<std::string>("HitTruthLabel", "gaushitTruthMatch"))
+  , fHitTruthLabel(p.get<std::string>("HitTruthLabel", ""))
 // More initializers here.
 {
   // Call appropriate produces<>() functions here.
@@ -92,8 +92,9 @@ void NuSliceHitsProducer::produce(art::Event& e)
 
   art::Handle<std::vector<recob::Hit>> hitListHandle;
   e.getByLabel(fHitLabel, hitListHandle);
-  std::unique_ptr<art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>> hittruth =
-    std::unique_ptr<art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>>(
+  std::unique_ptr<art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>> hittruth;
+  if (fHitTruthLabel != "")
+    hittruth = std::unique_ptr<art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>>(
       new art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>(
         hitListHandle, e, fHitTruthLabel));
 
@@ -111,6 +112,7 @@ void NuSliceHitsProducer::produce(art::Event& e)
       auto hit = sliceHits.at(ihit);
       outputHits->emplace_back(*hit);
 
+      if (fHitTruthLabel == "") continue;
       std::vector<art::Ptr<simb::MCParticle>> particle_vec = hittruth->at(hit.key());
       std::vector<anab::BackTrackerHitMatchingData const*> match_vec = hittruth->data(hit.key());
       const art::Ptr<recob::Hit> ahp = hitPtrMaker(outputHits->size() - 1);

--- a/larrecodnn/NuGraph/testinference_uB_slice_job.fcl
+++ b/larrecodnn/NuGraph/testinference_uB_slice_job.fcl
@@ -63,6 +63,8 @@ physics:
  end_paths:          [ streamROOT ]
 }
 
+#physics.producers.nuslhits.HitTruthLabel: "gaushitTruthMatch"
+
 physics.producers.sps.HitLabel: "nuslhits"
 physics.producers.sps.WireIntersectThreshold: 0.3
 physics.producers.sps.WireIntersectThresholdDriftDir: 0.3


### PR DESCRIPTION
This PR is a bug fix in how the vertex inference result is retrieved from the list of NuGraph outputs.
Note that the vertex decoder functionality is turned off by default.