### PR TITLE
Add setters and getters for the private members in PixelMapProducer

### DIFF
--- a/larrecodnn/CVN/interfaces/ICVNMapper.cxx
+++ b/larrecodnn/CVN/interfaces/ICVNMapper.cxx
@@ -29,7 +29,7 @@ namespace lcvn {
     auto const detProp =
       art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt);
     PixelMap pm = fProducer.CreateMap(detProp, hitlist);
-    auto nhits = fProducer.NROI();
+    auto nhits = fProducer.TotHits();
     pm.SetTotHits(nhits);
 
     if (nhits > fMinClusterHits) pmCol->push_back(pm);

--- a/larrecodnn/CVN/interfaces/PixelMapProducer.h
+++ b/larrecodnn/CVN/interfaces/PixelMapProducer.h
@@ -93,11 +93,7 @@ namespace lcvn {
     double Threshold() const { return fThreshold; }
     bool MultipleDrifts() const { return fMultipleDrifts; }
 
-    void SetNWire(unsigned int nwire) { fNWire = nwire; }
-    void SetNTdc(unsigned int ntdc) { fNTdc = ntdc; }
-    void SetTRes(double tres) { fTRes = tres; }
-    void SetTotHits(unsigned int tothits) {fTotHits = tothits; }
-    void SetThreshold(double threshold) {fThreshold = threshold; }
+    void SetTotHits(unsigned int tothits) { fTotHits = tothits; }
     void SetMultipleDrifts(bool multipledrifts = true) { fMultipleDrifts = multipledrifts; }
 
     /// Get boundaries for pixel map representation of cluster
@@ -113,7 +109,6 @@ namespace lcvn {
                                          unsigned int& globalWire,
                                          unsigned int& globalPlane,
                                          double& globalTDC) const;
-
 
     virtual PixelMap CreateMap(detinfo::DetectorPropertiesData const& detProp,
                                const std::vector<art::Ptr<T>>& cluster);

--- a/larrecodnn/CVN/interfaces/PixelMapProducer.h
+++ b/larrecodnn/CVN/interfaces/PixelMapProducer.h
@@ -86,8 +86,19 @@ namespace lcvn {
     // overload constructor for inputs from fcl
     PixelMapProducer(const fhicl::ParameterSet& pset);
 
-    void SetMultipleDrifts() { fMultipleDrifts = true; }
-    unsigned int NROI() { return fTotHits; };
+    unsigned int NWire() const { return fNWire; }
+    unsigned int NTdc() const { return fNTdc; }
+    double TRes() const { return fTRes; }
+    unsigned int TotHits() const { return fTotHits; }
+    double Threshold() const { return fThreshold; }
+    bool MultipleDrifts() const { return fMultipleDrifts; }
+
+    void SetNWire(unsigned int nwire) { fNWire = nwire; }
+    void SetNTdc(unsigned int ntdc) { fNTdc = ntdc; }
+    void SetTRes(double tres) { fTRes = tres; }
+    void SetTotHits(unsigned int tothits) {fTotHits = tothits; }
+    void SetThreshold(double threshold) {fThreshold = threshold; }
+    void SetMultipleDrifts(bool multipledrifts = true) { fMultipleDrifts = multipledrifts; }
 
     /// Get boundaries for pixel map representation of cluster
     virtual Boundary DefineBoundary(detinfo::DetectorPropertiesData const& detProp,
@@ -103,9 +114,6 @@ namespace lcvn {
                                          unsigned int& globalPlane,
                                          double& globalTDC) const;
 
-    unsigned int NWire() const { return fNWire; }
-    unsigned int NTdc() const { return fNTdc; }
-    double TRes() const { return fTRes; }
 
     virtual PixelMap CreateMap(detinfo::DetectorPropertiesData const& detProp,
                                const std::vector<art::Ptr<T>>& cluster);


### PR DESCRIPTION
Changes so the derived classes can access the private members in the base class. 

Adding setter functions because we need to modify some members such as fTotHits at a later stage. 