### PR TITLE
Changes applied in Spack package build process that need to be made for use with spack mpd

### DIFF
--- a/larrecodnn/ImageMaker/CMakeLists.txt
+++ b/larrecodnn/ImageMaker/CMakeLists.txt
@@ -22,7 +22,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
     CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12.5")
   # GCC 12.5 (and above) aggressively/spuriously warns about array-bounds issues.
   target_compile_options(larrecodnn_ImageMaker_SavePiMu_tool
-                         PRIVATE "-Wno-array-bounds;-Wno-stringop-overread")
+                         PRIVATE "-Wno-array-bounds;-Wno-stringop-overread;-Wno-stringop-overflow;-Wno-sign-compare")
 endif()
 
 install_headers()

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/TF/CMakeLists.txt
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/TF/CMakeLists.txt
@@ -4,6 +4,11 @@ cet_make_library(SOURCE
   TensorFlow::cc
   TensorFlow::framework
 )
-
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12.5")
+  # GCC 12.5 (and above) aggressively/spuriously warns about array-bounds issues.
+  target_compile_options(larrecodnn_ImagePatternAlgs_Tensorflow_TF
+                         PRIVATE "-Wno-sign-compare")
+endif()
 install_headers()
 install_source()

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
@@ -11,7 +11,6 @@
 
 #include "tf_graph.h"
 
-#include "tensorflow/cc/saved_model/bundle_v2.h"
 #include "tensorflow/cc/saved_model/constants.h"
 #include "tensorflow/cc/saved_model/loader.h"
 

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
@@ -11,7 +11,6 @@
 
 #include "tf_graph.h"
 
-#include "tensorflow/cc/saved_model/constants.h"
 #include "tensorflow/cc/saved_model/loader.h"
 
 #include "tensorflow/core/platform/env.h"

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
@@ -11,8 +11,10 @@
 
 #include "tf_graph.h"
 
+#include "tensorflow/cc/saved_model/bundle_v2.h"
+#include "tensorflow/cc/saved_model/constants.h"
 #include "tensorflow/cc/saved_model/loader.h"
-#include "tensorflow/cc/saved_model/tag_constants.h"
+
 #include "tensorflow/core/platform/env.h"
 
 #include "tensorflow/core/public/session_options.h"
@@ -50,7 +52,7 @@ tf::Graph::Graph(const char* graph_file_name,
     status = tensorflow::LoadSavedModel(tensorflow::SessionOptions(),
                                         tensorflow::RunOptions(),
                                         graph_file_name,
-                                        {tensorflow::kSavedModelTagServe},
+                                        {},
                                         fBundle);
     std::cout << "tf_graph loaded SavedModelBundle with status: " << status.ToString() << std::endl;
     if (!status.ok()) return;

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
@@ -49,7 +49,7 @@ tf::Graph::Graph(const char* graph_file_name,
 
     fBundle = new tensorflow::SavedModelBundle();
     status = tensorflow::LoadSavedModel(
-      tensorflow::SessionOptions(), tensorflow::RunOptions(), graph_file_name, {}, fBundle);
+      tensorflow::SessionOptions(), tensorflow::RunOptions(), graph_file_name, {"serve"}, fBundle);
     std::cout << "tf_graph loaded SavedModelBundle with status: " << status.ToString() << std::endl;
     if (!status.ok()) return;
 

--- a/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
+++ b/larrecodnn/ImagePatternAlgs/Tensorflow/TF/tf_graph.cc
@@ -49,11 +49,8 @@ tf::Graph::Graph(const char* graph_file_name,
   if (fUseBundle) {
 
     fBundle = new tensorflow::SavedModelBundle();
-    status = tensorflow::LoadSavedModel(tensorflow::SessionOptions(),
-                                        tensorflow::RunOptions(),
-                                        graph_file_name,
-                                        {},
-                                        fBundle);
+    status = tensorflow::LoadSavedModel(
+      tensorflow::SessionOptions(), tensorflow::RunOptions(), graph_file_name, {}, fBundle);
     std::cout << "tf_graph loaded SavedModelBundle with status: " << status.ToString() << std::endl;
     if (!status.ok()) return;
 

--- a/larrecodnn/NuGraph/CMakeLists.txt
+++ b/larrecodnn/NuGraph/CMakeLists.txt
@@ -32,14 +32,12 @@ cet_build_plugin(NuGraphInferenceSonicTriton art::EDProducer
     LIBRARIES PRIVATE
     lardataobj::RecoBase
     larrecodnn_ImagePatternAlgs_NuSonic_Triton
-    TorchScatter::TorchScatter
     IMPL_TARGET_VAR NuGraphInferenceSonicTriton_module
 )
 
 cet_build_plugin(NuGraphInferenceTriton art::EDProducer
     LIBRARIES PRIVATE
     lardataobj::RecoBase
-    TorchScatter::TorchScatter
     TritonClient::grpcclient
     gRPC::grpc # Should be a transitive (INTERFACE) dependency of TritonClient::grpcclient
     IMPL_TARGET_VAR NuGraphInferenceTriton_module


### PR DESCRIPTION
Also changes to Tensorflow includes that were deprecated in 2.15 and removed in 2.17.